### PR TITLE
feat: use byte-based language statistics instead of repo count

### DIFF
--- a/src/lib/components/portfolio/LanguageChart.svelte
+++ b/src/lib/components/portfolio/LanguageChart.svelte
@@ -13,6 +13,12 @@
 	const topLanguages = $derived(languages.slice(0, 5));
 	const total = $derived(topLanguages.reduce((sum, lang) => sum + lang.size, 0));
 
+	function formatBytes(bytes: number): string {
+		if (bytes >= 1_000_000) return `${(bytes / 1_000_000).toFixed(1)}MB`;
+		if (bytes >= 1_000) return `${(bytes / 1_000).toFixed(1)}KB`;
+		return `${bytes} bytes`;
+	}
+
 	// Calculate cumulative offsets for the donut chart
 	function calculateSegments(langs: LanguageStats[]) {
 		const segments: Array<{ lang: LanguageStats; offset: number; percentage: number }> = [];
@@ -91,7 +97,7 @@
 
 	{#if topLanguages.length > 0}
 		<div class="mt-4 text-xs text-text-tertiary">
-			Based on top {total} repos
+			Based on {formatBytes(total)} of code
 		</div>
 	{/if}
 </Card>

--- a/src/lib/types/github.ts
+++ b/src/lib/types/github.ts
@@ -33,6 +33,19 @@ export interface GitHubRepository {
 	topics: string[];
 	pushedAt: string | null;
 	createdAt: string;
+	languages?: RepositoryLanguages;
+}
+
+export interface RepositoryLanguageEdge {
+	size: number;
+	node: {
+		name: string;
+		color: string;
+	};
+}
+
+export interface RepositoryLanguages {
+	edges: RepositoryLanguageEdge[];
 }
 
 export interface ContributionDay {
@@ -133,6 +146,12 @@ export interface GraphQLUserResponse {
 				stargazerCount: number;
 				forkCount: number;
 				primaryLanguage: { name: string; color: string } | null;
+				languages: {
+					edges: Array<{
+						size: number;
+						node: { name: string; color: string };
+					}>;
+				};
 				isPrivate: boolean;
 				isFork: boolean;
 				isArchived: boolean;
@@ -152,6 +171,12 @@ export interface GraphQLUserResponse {
 				stargazerCount: number;
 				forkCount: number;
 				primaryLanguage: { name: string; color: string } | null;
+				languages: {
+					edges: Array<{
+						size: number;
+						node: { name: string; color: string };
+					}>;
+				};
 				isPrivate: boolean;
 				isFork: boolean;
 				isArchived: boolean;


### PR DESCRIPTION
- Add languages field to GraphQL query to get byte counts per language
- Update calculateLanguageStats to sum bytes across all repos
- Display total code size in chart footer (e.g., "Based on 1.9GB of code")
- Maintain REST API fallback using repo count when GraphQL unavailable

This provides more accurate language proficiency representation. Example: torvalds now shows 98% C instead of 42% C.