### PR TITLE
fix: update compatibility_date for nodejs_compat crypto support

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 name = "checkmygit"
 pages_build_output_dir = ".svelte-kit/cloudflare"
-compatibility_date = "2024-01-01"
+compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
 
 [[kv_namespaces]]


### PR DESCRIPTION
Cloudflare requires compatibility_date >= 2024-09-23 for the nodejs_compat flag to support bare Node.js module imports like 'crypto' (without the 'node:' prefix).