### PR TITLE
fix: use satori/standalone with explicit WASM init for CF Workers

### DIFF
--- a/src/lib/server/og/index.ts
+++ b/src/lib/server/og/index.ts
@@ -1,7 +1,7 @@
 // OG Image generation orchestrator
-// Combines font loading, card building, Satori SVG rendering, and Resvg PNG conversion
+// Uses satori/standalone with explicit WASM init for Cloudflare Workers compatibility
 
-import satori from 'satori';
+import satori, { init as initSatori } from 'satori/standalone';
 import type { GitHubProfile } from '$lib/types/github';
 import { loadFonts } from './font';
 import { ensureResvgInitialized, Resvg } from './resvg';
@@ -9,7 +9,24 @@ import { buildOGCard } from './card';
 
 const OG_WIDTH = 1200;
 const OG_HEIGHT = 630;
-const OG_SCALE = 2; // Render at 2x for crisp output
+const OG_SCALE = 2;
+
+const YOGA_WASM_URL = 'https://cdn.jsdelivr.net/npm/satori@0.26.0/yoga.wasm';
+
+let satoriReady = false;
+
+async function ensureSatoriInitialized(): Promise<void> {
+	if (satoriReady) return;
+
+	const yogaResponse = await fetch(YOGA_WASM_URL);
+	if (!yogaResponse.ok) {
+		throw new Error(`Failed to fetch yoga WASM: ${yogaResponse.status}`);
+	}
+
+	const yogaWasm = await yogaResponse.arrayBuffer();
+	await initSatori(yogaWasm);
+	satoriReady = true;
+}
 
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
 	const bytes = new Uint8Array(buffer);
@@ -36,8 +53,8 @@ async function fetchAvatarAsDataUrl(avatarUrl: string): Promise<string | null> {
 }
 
 export async function generateOGImage(profile: GitHubProfile): Promise<Uint8Array> {
-	// Initialize resvg WASM (cached after first call)
-	await ensureResvgInitialized();
+	// Initialize both WASM runtimes from CDN (cached after first call)
+	await Promise.all([ensureSatoriInitialized(), ensureResvgInitialized()]);
 
 	// Load fonts (cached after first call)
 	const fonts = await loadFonts();
@@ -48,7 +65,7 @@ export async function generateOGImage(profile: GitHubProfile): Promise<Uint8Arra
 	// Build the card virtual DOM
 	const cardVdom = buildOGCard(profile, avatarDataUrl);
 
-	// Render to SVG via Satori (yoga WASM is base64-inlined in yoga-layout)
+	// Render to SVG via Satori
 	const svg = await satori(cardVdom as any, {
 		width: OG_WIDTH,
 		height: OG_HEIGHT,
@@ -68,7 +85,7 @@ export async function generateOGImage(profile: GitHubProfile): Promise<Uint8Arra
 		]
 	});
 
-	// Convert SVG to PNG at 2x resolution for crisp output
+	// Convert SVG to PNG at 2x resolution
 	const resvg = new Resvg(svg, {
 		fitTo: { mode: 'width', value: OG_WIDTH * OG_SCALE }
 	});

--- a/src/lib/server/og/resvg.ts
+++ b/src/lib/server/og/resvg.ts
@@ -1,5 +1,5 @@
 // WASM initialization wrapper for @resvg/resvg-wasm
-// Fetches WASM binary from jsDelivr CDN (worker can't fetch its own static assets)
+// Loads WASM as ArrayBuffer from CDN (CF Workers need explicit init)
 
 import { initWasm, Resvg } from '@resvg/resvg-wasm';
 
@@ -15,7 +15,8 @@ export async function ensureResvgInitialized(): Promise<void> {
 		throw new Error(`Failed to fetch resvg WASM: ${wasmResponse.status}`);
 	}
 
-	await initWasm(wasmResponse);
+	const wasmBuffer = await wasmResponse.arrayBuffer();
+	await initWasm(wasmBuffer);
 	initialized = true;
 }
 

--- a/src/routes/api/og/[username]/+server.ts
+++ b/src/routes/api/og/[username]/+server.ts
@@ -77,15 +77,15 @@ export const GET: RequestHandler = async ({ params, platform }) => {
 
 		return response;
 	} catch (err) {
-		console.error('OG image generation failed:', err);
+		const errorMsg = err instanceof Error ? err.message : String(err);
+		console.error('OG image generation failed:', errorMsg);
 
-		// Graceful degradation: redirect to GitHub avatar
-		const avatarUrl = `${result.data.user.avatarUrl}&s=1200`;
-		return new Response(null, {
-			status: 302,
+		// Return error as JSON so we can debug on production
+		return new Response(JSON.stringify({ error: errorMsg }), {
+			status: 500,
 			headers: {
-				Location: avatarUrl,
-				'Cache-Control': 'public, max-age=300'
+				'Content-Type': 'application/json',
+				'Cache-Control': 'no-cache'
 			}
 		});
 	}


### PR DESCRIPTION
## Summary
- Switch from default `satori` to `satori/standalone` with manual yoga WASM initialization from CDN
- Pass `ArrayBuffer` (not `Response`) to resvg `initWasm` — CF Workers `WebAssembly.instantiateStreaming` may silently fail with Response objects
- Temporarily return error JSON (instead of silent avatar redirect) to surface actual failures

## Root cause
Both satori's yoga WASM and resvg WASM fail to initialize on CF Workers when using auto-init or Response-based init. Explicit ArrayBuffer-based init from external CDN is the reliable path.

## Test plan
- [ ] `curl -s https://checkmygit.com/api/og/whoisyurii | file -` should show PNG
- [ ] If still failing, the response will now be JSON with the actual error message