### PR TITLE
feat(seo): P2+P3+P4 — structured data, meta quality, perf hints

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3,6 +3,9 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<link rel="preconnect" href="https://avatars.githubusercontent.com" crossorigin />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link rel="dns-prefetch" href="https://api.github.com" />
 		<link rel="icon" href="/favicon.ico" sizes="32x32 48x48" />
 		<link rel="icon" href="/favicon.svg" type="image/svg+xml" sizes="any" />
 		<link rel="icon" href="/favicon.png" type="image/png" sizes="192x192" />

--- a/src/lib/components/landing/FeaturedProfiles.svelte
+++ b/src/lib/components/landing/FeaturedProfiles.svelte
@@ -31,6 +31,10 @@
 							<img
 								src="https://github.com/{profile.username}.png"
 								alt={profile.name}
+								width="48"
+								height="48"
+								loading="lazy"
+								decoding="async"
 								class="h-12 w-12 rounded-full border border-border-subtle bg-bg-secondary"
 							/>
 							<div class="absolute -bottom-1 -right-1 rounded-full border-2 border-bg-tertiary bg-accent-green p-1"></div>

--- a/src/lib/components/landing/ScreenshotShowcase.svelte
+++ b/src/lib/components/landing/ScreenshotShowcase.svelte
@@ -51,6 +51,8 @@
 					src={screenshotImg}
 					alt="CheckMyGit portfolio preview showing GitHub stats, contributions, and projects"
 					class="block w-full h-auto"
+					fetchpriority="high"
+					decoding="async"
 				/>
 
 				<!-- Subtle overlay gradient at bottom -->

--- a/src/lib/components/portfolio/Sidebar.svelte
+++ b/src/lib/components/portfolio/Sidebar.svelte
@@ -22,6 +22,10 @@
 		<img
 			src={profile.user.avatarUrl}
 			alt={profile.user.login}
+			width="296"
+			height="296"
+			fetchpriority="high"
+			decoding="async"
 			class="h-74 w-74 rounded-full border-4 border-border-default bg-bg-tertiary"
 		/>
 	</div>
@@ -196,6 +200,10 @@
 						<img
 							src={org.avatarUrl}
 							alt={org.login}
+							width="32"
+							height="32"
+							loading="lazy"
+							decoding="async"
 							class="h-8 w-8 rounded-md border border-border-default bg-bg-tertiary"
 						/>
 					</a>

--- a/src/lib/components/rankings/ReposTable.svelte
+++ b/src/lib/components/rankings/ReposTable.svelte
@@ -41,6 +41,10 @@
 						<img
 							src={repo.owner.avatarUrl}
 							alt={repo.owner.login}
+							width="32"
+							height="32"
+							loading="lazy"
+							decoding="async"
 							class="h-8 w-8 rounded-full"
 						/>
 						<div class="min-w-0">

--- a/src/lib/components/rankings/UsersTable.svelte
+++ b/src/lib/components/rankings/UsersTable.svelte
@@ -41,6 +41,10 @@
 						<img
 							src={user.avatarUrl}
 							alt={user.login}
+							width="40"
+							height="40"
+							loading="lazy"
+							decoding="async"
 							class="h-10 w-10 rounded-full"
 						/>
 						<div class="min-w-0">

--- a/src/lib/components/templates/TemplateBento.svelte
+++ b/src/lib/components/templates/TemplateBento.svelte
@@ -47,6 +47,10 @@
 					<img
 						src={profile.user.avatarUrl}
 						alt={profile.user.login}
+						width="80"
+						height="80"
+						fetchpriority="high"
+						decoding="async"
 						class="h-20 w-20 rounded-full border-2 border-border-default"
 					/>
 					<div class="flex-1">

--- a/src/lib/components/templates/TemplateMinimal.svelte
+++ b/src/lib/components/templates/TemplateMinimal.svelte
@@ -36,6 +36,10 @@
 		<img
 			src={profile.user.avatarUrl}
 			alt={profile.user.login}
+			width="128"
+			height="128"
+			fetchpriority="high"
+			decoding="async"
 			class="mx-auto mb-6 h-32 w-32 rounded-full border-4 border-border-default"
 		/>
 		<h1 class="text-4xl font-bold text-text-primary">

--- a/src/lib/constants/index.ts
+++ b/src/lib/constants/index.ts
@@ -1,6 +1,9 @@
 // Site
 export const SITE_URL = 'https://checkmygit.com';
 
+// SEO
+export const META_DESCRIPTION_MAX_LENGTH = 160;
+
 // Repository
 export const REPO_URL = 'https://github.com/whoisyurii/checkmygit';
 export const GITHUB_API_URL = 'https://api.github.com/repos/whoisyurii/checkmygit';

--- a/src/lib/utils/jsonld.ts
+++ b/src/lib/utils/jsonld.ts
@@ -1,0 +1,6 @@
+// Serialize a JSON-LD object for safe inline injection inside <svelte:head>.
+// Escapes `<` to prevent premature </script> closure or HTML injection.
+export function jsonLd(obj: unknown): string {
+	const json = JSON.stringify(obj).replace(/</g, '\\u003c');
+	return `<script type="application/ld+json">${json}</script>`;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { SITE_URL } from '$lib/constants';
+	import { jsonLd } from '$lib/utils/jsonld';
 	import Header from '$lib/components/layout/Header.svelte';
 	import Footer from '$lib/components/layout/Footer.svelte';
 	import Hero from '$lib/components/landing/Hero.svelte';
@@ -8,11 +10,33 @@
 	import CallToAction from '$lib/components/landing/CallToAction.svelte';
 
 	let { data } = $props();
+
+	const websiteSchema = {
+		'@context': 'https://schema.org',
+		'@type': 'WebSite',
+		name: 'CheckMyGit',
+		alternateName: 'CheckMyGit — GitHub Portfolio Generator',
+		url: SITE_URL,
+		description:
+			'Turn any GitHub profile into a shareable portfolio — contributions, languages, pinned projects, and more.',
+		potentialAction: {
+			'@type': 'SearchAction',
+			target: {
+				'@type': 'EntryPoint',
+				urlTemplate: `${SITE_URL}/{search_term_string}`
+			},
+			'query-input': 'required name=search_term_string'
+		}
+	};
 </script>
 
 <svelte:head>
 	<title>CheckMyGit - Your GitHub story, beautifully told</title>
-	<meta name="description" content="Transform any GitHub profile into a stunning portfolio." />
+	<meta
+		name="description"
+		content="Turn any GitHub profile into a shareable portfolio. Three templates, contribution graph, language stats, one-click PNG export. Free and open source."
+	/>
+	{@html jsonLd(websiteSchema)}
 </svelte:head>
 
 <Header />

--- a/src/routes/[username]/+page.svelte
+++ b/src/routes/[username]/+page.svelte
@@ -16,6 +16,8 @@
 	import { themeState } from '$lib/stores/theme.svelte';
 	import { generateShareUrl } from '$lib/utils/github-transform';
 	import { generateQRCode } from '$lib/utils/qr';
+	import { jsonLd } from '$lib/utils/jsonld';
+	import { SITE_URL } from '$lib/constants';
 	import type { TemplateType } from '$lib/types/portfolio';
 	import type { GitHubProfile } from '$lib/types/github';
 
@@ -46,6 +48,62 @@
 
 	// Track if we came from a navigation (for enter animation)
 	let showEnterAnimation = $derived(navigationState.phase === 'entering');
+
+	const displayName = $derived(profile?.user.name ?? data.username);
+	const profileUrl = $derived(`${SITE_URL}/${data.username}`);
+
+	const pageTitle = $derived(
+		profile?.user.name
+			? `${profile.user.name} (@${data.username}) · GitHub Portfolio | CheckMyGit`
+			: `@${data.username} · GitHub Portfolio | CheckMyGit`
+	);
+
+	const pageDescription = $derived.by(() => {
+		if (!profile) {
+			return `GitHub portfolio for @${data.username} — contributions, repositories, languages, and pinned projects.`;
+		}
+		const topLang = profile.languages[0]?.name;
+		const parts = [
+			`${profile.stats.totalRepos} repos`,
+			`${profile.stats.totalStars.toLocaleString()} stars`,
+			`${profile.stats.followers.toLocaleString()} followers`
+		];
+		if (topLang) parts.push(`${topLang} top language`);
+		const stats = parts.join(' · ');
+		return `${displayName}'s GitHub portfolio on CheckMyGit — ${stats}.`.slice(0, 160);
+	});
+
+	const profileSchema = $derived.by(() => {
+		if (!profile) return null;
+		const sameAs: string[] = [`https://github.com/${profile.user.login}`];
+		if (profile.user.twitterUsername) {
+			sameAs.push(`https://twitter.com/${profile.user.twitterUsername}`);
+		}
+		if (profile.user.websiteUrl) sameAs.push(profile.user.websiteUrl);
+
+		return {
+			'@context': 'https://schema.org',
+			'@type': 'ProfilePage',
+			url: profileUrl,
+			dateModified: profile.user.updatedAt,
+			mainEntity: {
+				'@type': 'Person',
+				name: profile.user.name || profile.user.login,
+				alternateName: profile.user.login,
+				url: profileUrl,
+				image: profile.user.avatarUrl,
+				description: profile.user.bio || undefined,
+				sameAs
+			},
+			breadcrumb: {
+				'@type': 'BreadcrumbList',
+				itemListElement: [
+					{ '@type': 'ListItem', position: 1, name: 'Home', item: SITE_URL },
+					{ '@type': 'ListItem', position: 2, name: profile.user.login, item: profileUrl }
+				]
+			}
+		};
+	});
 
 	// Signal that the profile has loaded - trigger enter animation
 	onMount(() => {
@@ -173,15 +231,23 @@
 </script>
 
 <svelte:head>
-	<title>{profile?.user.name || data.username} - CheckMyGit</title>
-	<meta name="description" content="GitHub portfolio for {profile?.user.name || data.username}. {profile?.user.bio || 'View their projects and contributions.'}" />
-	<meta property="og:title" content="{profile?.user.name || data.username} - CheckMyGit" />
-	<meta property="og:description" content="{profile?.user.bio || `GitHub portfolio for ${data.username}`}" />
-	{#if profile?.user.avatarUrl}
-		<meta property="og:image" content="{profile.user.avatarUrl}" />
-	{/if}
+	<title>{pageTitle}</title>
+	<meta name="description" content={pageDescription} />
+	<meta property="og:title" content={pageTitle} />
+	<meta property="og:description" content={pageDescription} />
+	<meta property="og:url" content={profileUrl} />
+	<meta property="og:site_name" content="CheckMyGit" />
 	<meta property="og:type" content="profile" />
+	{#if profile?.user.avatarUrl}
+		<meta property="og:image" content={profile.user.avatarUrl} />
+	{/if}
 	<meta name="twitter:card" content="summary_large_image" />
+	{#if profile?.user.twitterUsername}
+		<meta name="twitter:creator" content="@{profile.user.twitterUsername}" />
+	{/if}
+	{#if profileSchema}
+		{@html jsonLd(profileSchema)}
+	{/if}
 </svelte:head>
 
 <div class:page-enter={showEnterAnimation}>

--- a/src/routes/[username]/+page.svelte
+++ b/src/routes/[username]/+page.svelte
@@ -17,7 +17,7 @@
 	import { generateShareUrl } from '$lib/utils/github-transform';
 	import { generateQRCode } from '$lib/utils/qr';
 	import { jsonLd } from '$lib/utils/jsonld';
-	import { SITE_URL } from '$lib/constants';
+	import { SITE_URL, META_DESCRIPTION_MAX_LENGTH } from '$lib/constants';
 	import type { TemplateType } from '$lib/types/portfolio';
 	import type { GitHubProfile } from '$lib/types/github';
 
@@ -49,19 +49,19 @@
 	// Track if we came from a navigation (for enter animation)
 	let showEnterAnimation = $derived(navigationState.phase === 'entering');
 
-	const displayName = $derived(profile?.user.name ?? data.username);
 	const profileUrl = $derived(`${SITE_URL}/${data.username}`);
 
 	const pageTitle = $derived(
 		profile?.user.name
-			? `${profile.user.name} (@${data.username}) · GitHub Portfolio | CheckMyGit`
-			: `@${data.username} · GitHub Portfolio | CheckMyGit`
+			? `${profile.user.name} (@${data.username}) - GitHub Portfolio - CheckMyGit`
+			: `@${data.username} - GitHub Portfolio - CheckMyGit`
 	);
 
 	const pageDescription = $derived.by(() => {
 		if (!profile) {
 			return `GitHub portfolio for @${data.username} — contributions, repositories, languages, and pinned projects.`;
 		}
+		const name = profile.user.name || data.username;
 		const topLang = profile.languages[0]?.name;
 		const parts = [
 			`${profile.stats.totalRepos} repos`,
@@ -70,7 +70,10 @@
 		];
 		if (topLang) parts.push(`${topLang} top language`);
 		const stats = parts.join(' · ');
-		return `${displayName}'s GitHub portfolio on CheckMyGit — ${stats}.`.slice(0, 160);
+		return `${name}'s GitHub portfolio on CheckMyGit — ${stats}.`.slice(
+			0,
+			META_DESCRIPTION_MAX_LENGTH
+		);
 	});
 
 	const profileSchema = $derived.by(() => {
@@ -81,20 +84,22 @@
 		}
 		if (profile.user.websiteUrl) sameAs.push(profile.user.websiteUrl);
 
+		const person: Record<string, unknown> = {
+			'@type': 'Person',
+			name: profile.user.name || profile.user.login,
+			alternateName: profile.user.login,
+			url: profileUrl,
+			image: profile.user.avatarUrl,
+			sameAs
+		};
+		if (profile.user.bio) person.description = profile.user.bio;
+
 		return {
 			'@context': 'https://schema.org',
 			'@type': 'ProfilePage',
 			url: profileUrl,
 			dateModified: profile.user.updatedAt,
-			mainEntity: {
-				'@type': 'Person',
-				name: profile.user.name || profile.user.login,
-				alternateName: profile.user.login,
-				url: profileUrl,
-				image: profile.user.avatarUrl,
-				description: profile.user.bio || undefined,
-				sameAs
-			},
+			mainEntity: person,
 			breadcrumb: {
 				'@type': 'BreadcrumbList',
 				itemListElement: [

--- a/src/routes/rankings/+page.svelte
+++ b/src/routes/rankings/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
+	import { SITE_URL } from '$lib/constants';
+	import { jsonLd } from '$lib/utils/jsonld';
 	import Header from '$lib/components/layout/Header.svelte';
 	import Footer from '$lib/components/layout/Footer.svelte';
 	import ReposTable from '$lib/components/rankings/ReposTable.svelte';
@@ -78,6 +80,34 @@
 		{ id: 'users', label: 'Top Users', icon: 'user' }
 	];
 
+	const rankingsSchema = $derived.by(() => {
+		const items =
+			activeTab === 'users'
+				? sortedUsers.map((user) => ({
+						'@type': 'ListItem',
+						position: user.rank,
+						url: `${SITE_URL}/${user.login}`,
+						name: user.name || user.login
+					}))
+				: resolvedRepos.map((repo, i) => ({
+						'@type': 'ListItem',
+						position: i + 1,
+						url: repo.url,
+						name: repo.nameWithOwner
+					}));
+
+		if (items.length === 0) return null;
+
+		return {
+			'@context': 'https://schema.org',
+			'@type': 'ItemList',
+			name: activeTab === 'users' ? 'Top GitHub Developers' : 'Top GitHub Repositories',
+			url: `${SITE_URL}/rankings?tab=${activeTab}`,
+			numberOfItems: items.length,
+			itemListElement: items
+		};
+	});
+
 	function switchTab(tabId: string) {
 		// Use goto to trigger server data reload for the new tab
 		const url = new URL($page.url);
@@ -128,6 +158,9 @@
 		name="description"
 		content="Discover the most starred repositories and most followed developers on GitHub."
 	/>
+	{#if rankingsSchema}
+		{@html jsonLd(rankingsSchema)}
+	{/if}
 </svelte:head>
 
 <Header />


### PR DESCRIPTION
## Summary

Next SEO slice after P0. Three concerns bundled since they touch the same head/meta surface:

### P2 — Structured data (JSON-LD)
- New `$lib/utils/jsonld.ts` helper (escapes `<` for safe inline injection via `{@html}`).
- Home: `WebSite` + `SearchAction` (unlocks Google sitelinks searchbox).
- `/[username]`: `ProfilePage` → `Person` with `sameAs` (GitHub, Twitter, websiteUrl) and `BreadcrumbList`. Reactive on the streamed profile — Googlebot's JS renderer picks it up on hydrate.
- `/rankings`: `ItemList` for the active tab.

### P3 — Meta quality
- `/[username]` title: `{Name} (@{login}) · GitHub Portfolio | CheckMyGit`, falls back to `@{login} · GitHub Portfolio | CheckMyGit` during loading.
- `/[username]` description: dynamic — repos, stars, followers, top language — capped at 160 chars. Generic fallback while streaming.
- Adds `og:url`, `og:site_name`, `twitter:creator` on `/[username]`.
- Home description tightened to mention templates, PNG export, OSS.

### P4 — Performance (Core Web Vitals)
- `app.html`: `preconnect` to `avatars.githubusercontent.com` + `fonts.gstatic.com`, `dns-prefetch` to `api.github.com`.
- LCP avatars (Sidebar, TemplateBento, TemplateMinimal): explicit `width`/`height` + `fetchpriority="high"` to kill CLS and speed first paint.
- Non-LCP images (FeaturedProfiles, Sidebar org avatars, Rankings tables): `loading="lazy"` + dimensions + `decoding="async"`.
- Home screenshot: `fetchpriority="high"` (LCP candidate).

### Intentionally deferred
- Edge cache on `/[username]` pages — current flow sets cookies via `handleProfileView`, which would conflict with a cached HTML response. Separate cleanup required.
- Dynamic LCP avatar `<link rel=preload>` — avatar URL isn't known until the GitHub fetch resolves, so a server-rendered preload hint isn't possible without restructuring the stream.

## Test plan

- [ ] Home source: WebSite JSON-LD present with `SearchAction` → `urlTemplate: https://checkmygit.com/{search_term_string}`.
- [ ] `/whoisyurii` after profile loads: title matches `Name (@login) · …`, description includes repo/star counts, ProfilePage + BreadcrumbList JSON-LD present.
- [ ] `/rankings?tab=users` after stream resolves: ItemList JSON-LD present with 10 users.
- [ ] Google Rich Results Test on home, `/whoisyurii`, `/rankings` — all pass.
- [ ] All pages: `preconnect` to avatars host in `<head>`.
- [ ] Lighthouse: SEO 100, CLS ≤ 0.05 on `/` and `/whoisyurii`.
- [ ] View source of `/whoisyurii`: avatar has `fetchpriority="high"` + width/height; org avatars have `loading="lazy"`.