### PR TITLE
feat(trending): /trending page with optimistic UI + reusable SegmentedTabs

### DIFF
--- a/src/lib/components/layout/header/HeaderActions.svelte
+++ b/src/lib/components/layout/header/HeaderActions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Button from '$lib/components/ui/Button.svelte';
+	import FireIcon from '$lib/components/ui/FireIcon.svelte';
 	import ThemeToggle from '$lib/components/ui/ThemeToggle.svelte';
 	import { REPO_URL, GITHUB_API_URL } from '$lib/constants';
 
@@ -36,10 +37,21 @@
 </script>
 
 <div class="flex shrink-0 items-center gap-2">
+	<!-- Trending Link -->
+	<Button variant="ghost" size="sm" href="/trending">
+		<FireIcon size={16} />
+		<span class="hidden sm:inline">Trending</span>
+	</Button>
+
 	<!-- Rankings Link -->
 	<Button variant="ghost" size="sm" href="/rankings">
 		<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-			<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="2"
+				d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+			/>
 		</svg>
 		<span class="hidden sm:inline">Rankings</span>
 	</Button>
@@ -47,19 +59,34 @@
 	{#if showControls}
 		<Button variant="ghost" size="sm" onclick={onExport} class="hidden! sm:inline-flex!">
 			<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="2"
+					d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+				/>
 			</svg>
 			<span class="hidden sm:inline">Export</span>
 		</Button>
 		<Button variant="ghost" size="sm" onclick={onShare}>
 			<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"/>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="2"
+					d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+				/>
 			</svg>
 			<span class="hidden sm:inline">Share</span>
 		</Button>
 		<Button variant="ghost" size="sm" onclick={onQRCode}>
 			<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z"/>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="2"
+					d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z"
+				/>
 			</svg>
 			<span class="hidden sm:inline">QR</span>
 		</Button>
@@ -69,7 +96,9 @@
 
 	<Button variant="secondary" size="sm" href={REPO_URL} target="_blank">
 		<svg class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
-			<path d="M12 .587l3.668 7.568 8.332 1.151-6.064 5.828 1.48 8.279-7.416-3.967-7.417 3.967 1.481-8.279-6.064-5.828 8.332-1.151z"/>
+			<path
+				d="M12 .587l3.668 7.568 8.332 1.151-6.064 5.828 1.48 8.279-7.416-3.967-7.417 3.967 1.481-8.279-6.064-5.828 8.332-1.151z"
+			/>
 		</svg>
 		{#if starCount !== null}
 			<span>{formatStarCount(starCount)} <span class="hidden sm:inline">Github</span></span>

--- a/src/lib/components/rankings/TrendingFilters.svelte
+++ b/src/lib/components/rankings/TrendingFilters.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import Dropdown from '$lib/components/ui/Dropdown.svelte';
+	import { RANKING_LANGUAGES } from '$lib/types/rankings';
+
+	interface Props {
+		language: string;
+		onchange: (value: string) => void;
+	}
+
+	let { language, onchange }: Props = $props();
+
+	const options = [
+		{ value: '', label: 'All Languages' },
+		...RANKING_LANGUAGES.map((lang) => ({ value: lang, label: lang }))
+	];
+</script>
+
+<div class="flex items-center gap-2">
+	<span class="text-sm text-[var(--color-text-secondary)]">Language:</span>
+	<Dropdown {options} value={language} placeholder="All Languages" {onchange} class="w-40" />
+</div>

--- a/src/lib/components/rankings/TrendingTable.svelte
+++ b/src/lib/components/rankings/TrendingTable.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+	import * as Table from '$lib/components/ui/table';
+	import Badge from '$lib/components/ui/Badge.svelte';
+	import FireIcon from '$lib/components/ui/FireIcon.svelte';
+	import { formatNumber } from '$lib/utils/github-transform';
+	import type { TrendingRepository, TrendingWindow } from '$lib/types/trending';
+	import { WINDOW_PERIOD_TEXT } from '$lib/types/trending';
+
+	interface Props {
+		repos: TrendingRepository[];
+		since: TrendingWindow;
+	}
+
+	let { repos, since }: Props = $props();
+</script>
+
+<Table.Root>
+	<Table.Header>
+		<Table.Row>
+			<Table.Head class="w-12">#</Table.Head>
+			<Table.Head>Repository</Table.Head>
+			<Table.Head class="text-right">Stars {WINDOW_PERIOD_TEXT[since]}</Table.Head>
+			<Table.Head class="hidden text-right sm:table-cell">Total</Table.Head>
+			<Table.Head class="hidden md:table-cell">Language</Table.Head>
+		</Table.Row>
+	</Table.Header>
+	<Table.Body>
+		{#each repos as repo (repo.nameWithOwner)}
+			<Table.Row href={repo.url} target="_blank">
+				<Table.Cell class="font-medium text-text-secondary">{repo.rank}</Table.Cell>
+				<Table.Cell>
+					<div class="flex items-center gap-3">
+						<a
+							href="/{repo.owner}"
+							class="shrink-0"
+							aria-label="View {repo.owner}'s CheckMyGit portfolio"
+							onclick={(e) => e.stopPropagation()}
+						>
+							<img
+								src={repo.avatarUrl}
+								alt={repo.owner}
+								loading="lazy"
+								class="h-8 w-8 rounded-full hover:ring-2 hover:ring-accent-blue"
+							/>
+						</a>
+						<div class="min-w-0">
+							<a
+								href={repo.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="block truncate font-medium text-text-primary hover:text-accent-blue"
+								onclick={(e) => e.stopPropagation()}
+							>
+								{repo.nameWithOwner}
+							</a>
+							{#if repo.description}
+								<p class="max-w-[300px] truncate text-sm text-text-secondary md:max-w-[400px]">
+									{repo.description}
+								</p>
+							{/if}
+						</div>
+					</div>
+				</Table.Cell>
+				<Table.Cell class="text-right">
+					{#if repo.periodStars > 0}
+						<div class="flex items-center justify-end gap-1.5">
+							<FireIcon size={16} animated={false} />
+							<span class="font-semibold text-text-primary">+{formatNumber(repo.periodStars)}</span>
+						</div>
+					{:else}
+						<span class="text-text-tertiary">—</span>
+					{/if}
+				</Table.Cell>
+				<Table.Cell class="hidden text-right sm:table-cell">
+					<div class="flex items-center justify-end gap-1 text-text-secondary">
+						<svg class="h-4 w-4 text-accent-yellow" fill="currentColor" viewBox="0 0 24 24">
+							<path
+								d="M12 .587l3.668 7.568 8.332 1.151-6.064 5.828 1.48 8.279-7.416-3.967-7.417 3.967 1.481-8.279-6.064-5.828 8.332-1.151z"
+							/>
+						</svg>
+						<span>{formatNumber(repo.stargazerCount)}</span>
+					</div>
+				</Table.Cell>
+				<Table.Cell class="hidden md:table-cell">
+					{#if repo.language}
+						<Badge color={repo.language.color}>{repo.language.name}</Badge>
+					{:else}
+						<span class="text-text-tertiary">—</span>
+					{/if}
+				</Table.Cell>
+			</Table.Row>
+		{/each}
+	</Table.Body>
+</Table.Root>

--- a/src/lib/components/rankings/TrendingTableSkeleton.svelte
+++ b/src/lib/components/rankings/TrendingTableSkeleton.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import * as Table from '$lib/components/ui/table';
+	import Skeleton from '$lib/components/ui/Skeleton.svelte';
+</script>
+
+<Table.Root>
+	<Table.Header>
+		<Table.Row>
+			<Table.Head class="w-12">#</Table.Head>
+			<Table.Head>Repository</Table.Head>
+			<Table.Head class="text-right">Period stars</Table.Head>
+			<Table.Head class="hidden text-right sm:table-cell">Total</Table.Head>
+			<Table.Head class="hidden md:table-cell">Language</Table.Head>
+		</Table.Row>
+	</Table.Header>
+	<Table.Body>
+		{#each Array(10) as _, i (i)}
+			<Table.Row>
+				<Table.Cell>
+					<Skeleton width="20px" height="20px" variant="rectangular" />
+				</Table.Cell>
+				<Table.Cell>
+					<div class="flex items-center gap-3">
+						<Skeleton variant="circular" width="32px" height="32px" />
+						<div class="flex flex-col gap-2">
+							<Skeleton width="180px" height="16px" variant="rectangular" />
+							<Skeleton width="260px" height="14px" variant="rectangular" />
+						</div>
+					</div>
+				</Table.Cell>
+				<Table.Cell class="text-right">
+					<Skeleton width="60px" height="16px" variant="rectangular" class="ml-auto" />
+				</Table.Cell>
+				<Table.Cell class="hidden text-right sm:table-cell">
+					<Skeleton width="50px" height="16px" variant="rectangular" class="ml-auto" />
+				</Table.Cell>
+				<Table.Cell class="hidden md:table-cell">
+					<Skeleton width="70px" height="22px" variant="rectangular" />
+				</Table.Cell>
+			</Table.Row>
+		{/each}
+	</Table.Body>
+</Table.Root>

--- a/src/lib/components/ui/FireIcon.svelte
+++ b/src/lib/components/ui/FireIcon.svelte
@@ -1,0 +1,76 @@
+<script lang="ts" module>
+	let counter = 0;
+	function nextGradId() {
+		counter += 1;
+		return `fire-grad-${counter}`;
+	}
+</script>
+
+<script lang="ts">
+	interface Props {
+		size?: number | string;
+		class?: string;
+		animated?: boolean;
+	}
+
+	let { size = 20, class: className = '', animated = true }: Props = $props();
+
+	const dim = $derived(typeof size === 'number' ? `${size}px` : size);
+	const gradId = nextGradId();
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	viewBox="0 0 24 24"
+	width={dim}
+	height={dim}
+	class="fire-icon {animated ? 'fire-icon--animated' : ''} {className}"
+	aria-hidden="true"
+	focusable="false"
+>
+	<defs>
+		<linearGradient id={gradId} x1="0%" y1="0%" x2="0%" y2="100%">
+			<stop offset="0%" stop-color="#fbbf24" />
+			<stop offset="55%" stop-color="#f97316" />
+			<stop offset="100%" stop-color="#ef4444" />
+		</linearGradient>
+	</defs>
+	<path
+		fill="url(#{gradId})"
+		d="M13.5 1c.3 2.6-1.4 4.3-2.7 5.7C9.4 8.2 8 9.6 8 12c0 1.4.6 2.6 1.5 3.4-.4-.7-.6-1.5-.5-2.3.2-1.7 1.7-2.6 2.6-3.7.6 1.3 1.6 2 2.5 3 1 1.1 1.7 2.4 1.6 3.9 0 .3-.1.7-.2 1 1.5-.9 2.5-2.5 2.5-4.4 0-2.3-1.1-4.3-2.6-6C13.7 5.1 13.4 3.1 13.5 1zM10.5 17.5c0 1.4 1 2.5 2.3 2.7 1.6.3 3-.9 3.1-2.4.1-1-.4-1.9-1.2-2.5.1.5 0 1.1-.4 1.5-.5.6-1.4.6-2 .1-.5-.5-.6-1.3-.2-1.9-.9.5-1.6 1.4-1.6 2.5z"
+	/>
+</svg>
+
+<style>
+	.fire-icon {
+		display: inline-block;
+		flex-shrink: 0;
+		transform-origin: center bottom;
+		filter: drop-shadow(0 0 2px rgba(249, 115, 22, 0.35));
+	}
+
+	.fire-icon--animated {
+		animation: flame-flicker 0.6s ease-in-out infinite alternate;
+	}
+
+	@keyframes flame-flicker {
+		0% {
+			transform: scale(1) rotate(0deg);
+			opacity: 0.92;
+		}
+		50% {
+			transform: scale(1.08) rotate(2deg);
+			opacity: 1;
+		}
+		100% {
+			transform: scale(1.04) rotate(-2deg);
+			opacity: 0.96;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.fire-icon--animated {
+			animation: none;
+		}
+	}
+</style>

--- a/src/lib/components/ui/SegmentedTabs.svelte
+++ b/src/lib/components/ui/SegmentedTabs.svelte
@@ -1,0 +1,41 @@
+<script lang="ts" generics="T extends string">
+	import type { Snippet } from 'svelte';
+
+	interface Item {
+		value: T;
+		label: string;
+	}
+
+	interface Props {
+		items: Item[];
+		value: T;
+		onchange: (value: T) => void;
+		ariaLabel?: string;
+		icon?: Snippet<[{ item: Item; active: boolean }]>;
+	}
+
+	let { items, value, onchange, ariaLabel = 'Tabs', icon }: Props = $props();
+</script>
+
+<div
+	class="inline-flex gap-1 rounded-lg border border-border-default bg-bg-secondary p-1"
+	role="tablist"
+	aria-label={ariaLabel}
+>
+	{#each items as item (item.value)}
+		{@const active = item.value === value}
+		<button
+			type="button"
+			role="tab"
+			aria-selected={active}
+			onclick={() => onchange(item.value)}
+			class="flex cursor-pointer items-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-all
+				{active
+				? 'bg-bg-primary text-text-primary shadow-sm ring-1 ring-border-default/60'
+				: 'text-text-secondary hover:bg-bg-tertiary/60 hover:text-text-primary'}"
+		>
+			{#if icon}{@render icon({ item, active })}{/if}
+			{item.label}
+		</button>
+	{/each}
+</div>

--- a/src/lib/components/ui/table/table-row.svelte
+++ b/src/lib/components/ui/table/table-row.svelte
@@ -4,17 +4,31 @@
 	interface Props {
 		class?: string;
 		href?: string;
+		target?: '_blank' | '_self';
 		children: Snippet;
 	}
 
-	let { class: className = '', href, children }: Props = $props();
+	let { class: className = '', href, target = '_self', children }: Props = $props();
 
 	const baseClasses = 'border-b border-[var(--color-border-default)] transition-colors';
-	const hoverClasses = $derived(href ? 'hover:bg-[var(--color-bg-tertiary)] cursor-pointer' : 'hover:bg-[var(--color-bg-tertiary)]/50');
+	const hoverClasses = $derived(
+		href
+			? 'hover:bg-[var(--color-bg-tertiary)] cursor-pointer'
+			: 'hover:bg-[var(--color-bg-tertiary)]/50'
+	);
+
+	function handleClick() {
+		if (!href) return;
+		if (target === '_blank') {
+			window.open(href, '_blank', 'noopener,noreferrer');
+		} else {
+			window.location.href = href;
+		}
+	}
 </script>
 
 {#if href}
-	<tr class="{baseClasses} {hoverClasses} {className}" onclick={() => window.location.href = href}>
+	<tr class="{baseClasses} {hoverClasses} {className}" onclick={handleClick}>
 		{@render children()}
 	</tr>
 {:else}

--- a/src/lib/server/trending.ts
+++ b/src/lib/server/trending.ts
@@ -1,0 +1,198 @@
+import type { TrendingRepository, TrendingResult, TrendingWindow } from '$lib/types/trending';
+import { fetchTopRepositories } from './rankings';
+
+const TRENDING_URL = 'https://github.com/trending';
+const USER_AGENT = 'CheckMyGit/1.0 (+https://checkmygit.com)';
+
+const TTL_BY_WINDOW: Record<TrendingWindow, { fresh: number; swr: number }> = {
+	daily: { fresh: 60 * 60, swr: 60 * 60 * 6 },
+	weekly: { fresh: 60 * 60 * 6, swr: 60 * 60 * 24 },
+	monthly: { fresh: 60 * 60 * 24, swr: 60 * 60 * 24 * 7 }
+};
+
+function buildCacheKey(since: TrendingWindow, language: string | undefined): string {
+	const lang = language ? language.toLowerCase() : 'all';
+	return `https://kv-cache/_/trending/${since}/${lang}`;
+}
+
+function buildTrendingUrl(since: TrendingWindow, language: string | undefined): string {
+	const params = new URLSearchParams({ since });
+	const url = new URL(TRENDING_URL);
+	if (language) url.pathname = `/trending/${encodeURIComponent(language.toLowerCase())}`;
+	url.search = params.toString();
+	return url.toString();
+}
+
+const ARTICLE_RE = /<article class="Box-row">([\s\S]*?)<\/article>/g;
+const REPO_HREF_RE = /<h2 class="h3 lh-condensed">[\s\S]*?<a [^>]*href="\/([^"]+)"/;
+const DESC_RE = /<p class="col-9 color-fg-muted my-1 tmp-pr-4">\s*([\s\S]*?)\s*<\/p>/;
+const LANG_NAME_RE = /<span itemprop="programmingLanguage">([^<]+)<\/span>/;
+const LANG_COLOR_RE = /<span class="repo-language-color" style="background-color:\s*([^"]+)"/;
+const STARS_RE = /href="\/[^"]+\/stargazers"[\s\S]*?<\/svg>\s*([\d,]+)\s*<\/a>/;
+const FORKS_RE = /href="\/[^"]+\/forks"[\s\S]*?<\/svg>\s*([\d,]+)\s*<\/a>/;
+const PERIOD_STARS_RE = /class="d-inline-block float-sm-right">[\s\S]*?<\/svg>\s*([\d,]+)\s+stars/;
+
+function decodeHtmlEntities(s: string): string {
+	return s
+		.replace(/&amp;/g, '&')
+		.replace(/&lt;/g, '<')
+		.replace(/&gt;/g, '>')
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.replace(/&nbsp;/g, ' ');
+}
+
+function parseNumberWithCommas(text: string): number {
+	return parseInt(text.replace(/,/g, ''), 10) || 0;
+}
+
+function parseTrendingHtml(html: string): TrendingRepository[] {
+	const repos: TrendingRepository[] = [];
+	let match: RegExpExecArray | null;
+	let rank = 0;
+
+	ARTICLE_RE.lastIndex = 0;
+	while ((match = ARTICLE_RE.exec(html)) !== null) {
+		const block = match[1];
+		const repoMatch = REPO_HREF_RE.exec(block);
+		if (!repoMatch) continue;
+
+		const path = repoMatch[1].trim();
+		const [owner, name] = path.split('/');
+		if (!owner || !name) continue;
+
+		const descMatch = DESC_RE.exec(block);
+		const description = descMatch
+			? decodeHtmlEntities(descMatch[1].replace(/\s+/g, ' ').trim())
+			: null;
+
+		const langName = LANG_NAME_RE.exec(block)?.[1] ?? null;
+		const langColor = LANG_COLOR_RE.exec(block)?.[1]?.trim() ?? null;
+		const language = langName ? { name: langName, color: langColor || '#888' } : null;
+
+		const starsMatch = STARS_RE.exec(block);
+		const forksMatch = FORKS_RE.exec(block);
+		const periodMatch = PERIOD_STARS_RE.exec(block);
+
+		rank += 1;
+		repos.push({
+			rank,
+			owner,
+			name,
+			nameWithOwner: `${owner}/${name}`,
+			url: `https://github.com/${owner}/${name}`,
+			description: description || null,
+			language,
+			stargazerCount: starsMatch ? parseNumberWithCommas(starsMatch[1]) : 0,
+			forkCount: forksMatch ? parseNumberWithCommas(forksMatch[1]) : 0,
+			periodStars: periodMatch ? parseNumberWithCommas(periodMatch[1]) : 0,
+			avatarUrl: `https://avatars.githubusercontent.com/${owner}?size=80`
+		});
+	}
+
+	return repos;
+}
+
+async function fetchAndParse(
+	since: TrendingWindow,
+	language: string | undefined
+): Promise<TrendingRepository[]> {
+	const response = await fetch(buildTrendingUrl(since, language), {
+		headers: { 'User-Agent': USER_AGENT, Accept: 'text/html' },
+		cf: { cacheTtl: TTL_BY_WINDOW[since].fresh, cacheEverything: true }
+	} as RequestInit);
+
+	if (!response.ok) {
+		throw new Error(`GitHub trending fetch failed: ${response.status}`);
+	}
+
+	const html = await response.text();
+	return parseTrendingHtml(html);
+}
+
+interface FetchTrendingOptions {
+	since: TrendingWindow;
+	language?: string;
+	caches?: CacheStorage & { default: Cache };
+	waitUntil?: (p: Promise<unknown>) => void;
+}
+
+export async function fetchTrending({
+	since,
+	language,
+	caches,
+	waitUntil
+}: FetchTrendingOptions): Promise<TrendingResult> {
+	const cacheKey = buildCacheKey(since, language);
+	const ttl = TTL_BY_WINDOW[since];
+
+	if (caches) {
+		const cached = await caches.default.match(new Request(cacheKey));
+		if (cached) {
+			const data = (await cached.json()) as TrendingRepository[];
+			return { success: true, data, source: 'cache' };
+		}
+	}
+
+	try {
+		const data = await fetchAndParse(since, language);
+		if (data.length === 0) throw new Error('Parsed zero repositories');
+
+		if (caches) {
+			const cacheResponse = new Response(JSON.stringify(data), {
+				headers: {
+					'Content-Type': 'application/json',
+					'Cache-Control': `public, max-age=${ttl.fresh}, stale-while-revalidate=${ttl.swr}`
+				}
+			});
+			const put = caches.default.put(new Request(cacheKey), cacheResponse);
+			if (waitUntil) waitUntil(put);
+			else await put;
+		}
+
+		return { success: true, data, source: 'live' };
+	} catch (error) {
+		const fallback = await fetchTopRepositories(language, 25, true);
+		if (fallback.success) {
+			const data: TrendingRepository[] = fallback.data.map((r) => ({
+				rank: r.rank,
+				owner: r.owner.login,
+				name: r.nameWithOwner.split('/')[1] ?? r.nameWithOwner,
+				nameWithOwner: r.nameWithOwner,
+				url: r.url,
+				description: r.description,
+				language: r.primaryLanguage,
+				stargazerCount: r.stargazerCount,
+				forkCount: r.forkCount,
+				periodStars: 0,
+				avatarUrl: r.owner.avatarUrl
+			}));
+			// Cache the fallback shorter than fresh TTL so a github.com/trending outage
+			// doesn't hammer the GraphQL API on every request, but recovers quickly.
+			if (caches) {
+				const cacheResponse = new Response(JSON.stringify(data), {
+					headers: {
+						'Content-Type': 'application/json',
+						'Cache-Control': `public, max-age=${Math.min(ttl.fresh, 1800)}`
+					}
+				});
+				const put = caches.default.put(new Request(cacheKey), cacheResponse);
+				if (waitUntil) waitUntil(put);
+				else await put;
+			}
+			return {
+				success: true,
+				data,
+				source: 'fallback',
+				error: error instanceof Error ? error.message : 'Unknown error'
+			};
+		}
+
+		return {
+			success: false,
+			data: [],
+			source: 'fallback',
+			error: error instanceof Error ? error.message : 'Unknown error'
+		};
+	}
+}

--- a/src/lib/types/trending.ts
+++ b/src/lib/types/trending.ts
@@ -1,0 +1,56 @@
+import { RANKING_LANGUAGES } from './rankings';
+
+export type TrendingWindow = 'daily' | 'weekly' | 'monthly';
+
+export const TRENDING_WINDOWS: ReadonlyArray<TrendingWindow> = [
+	'daily',
+	'weekly',
+	'monthly'
+] as const;
+
+export const DEFAULT_TRENDING_WINDOW: TrendingWindow = 'daily';
+
+export function normalizeTrendingWindow(value: string | null): TrendingWindow {
+	return TRENDING_WINDOWS.includes(value as TrendingWindow)
+		? (value as TrendingWindow)
+		: DEFAULT_TRENDING_WINDOW;
+}
+
+export function normalizeTrendingLanguage(value: string | null): string {
+	if (!value) return '';
+	const match = RANKING_LANGUAGES.find((l) => l.toLowerCase() === value.toLowerCase());
+	return match ?? '';
+}
+
+export interface TrendingRepository {
+	rank: number;
+	owner: string;
+	name: string;
+	nameWithOwner: string;
+	url: string;
+	description: string | null;
+	language: { name: string; color: string } | null;
+	stargazerCount: number;
+	forkCount: number;
+	periodStars: number;
+	avatarUrl: string;
+}
+
+export interface TrendingResult {
+	success: boolean;
+	data: TrendingRepository[];
+	error?: string;
+	source: 'live' | 'cache' | 'fallback';
+}
+
+export const WINDOW_LABEL: Record<TrendingWindow, string> = {
+	daily: 'Today',
+	weekly: 'This Week',
+	monthly: 'This Month'
+};
+
+export const WINDOW_PERIOD_TEXT: Record<TrendingWindow, string> = {
+	daily: 'today',
+	weekly: 'this week',
+	monthly: 'this month'
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,6 +13,12 @@
 	// Check if we're in exiting phase
 	let isExiting = $derived(navigationState.phase === 'exiting');
 
+	// Pages set `ownsCanonical: true` in their load data when they emit their own
+	// query-param-aware canonical, so the layout default doesn't duplicate it.
+	let pageOwnsCanonical = $derived(
+		($page.data as { ownsCanonical?: boolean }).ownsCanonical === true
+	);
+
 	// Initialize theme on mount
 	$effect(() => {
 		themeState.init();
@@ -22,7 +28,9 @@
 <svelte:head>
 	<meta name="theme-color" content={themeState.isDark ? '#030303' : '#FFFFFF'} />
 	<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-	<link rel="canonical" href="{SITE_URL}{$page.url.pathname}" />
+	{#if !pageOwnsCanonical}
+		<link rel="canonical" href="{SITE_URL}{$page.url.pathname}" />
+	{/if}
 </svelte:head>
 
 <div class="min-h-screen bg-bg-primary" class:page-exit={isExiting}>
@@ -34,7 +42,7 @@
 
 <!-- Toast Container -->
 {#if toastState.toasts.length > 0}
-	<div class="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+	<div class="fixed right-4 bottom-4 z-50 flex flex-col gap-2">
 		{#each toastState.toasts as toast (toast.id)}
 			<Toast
 				type={toast.type}

--- a/src/routes/api/trending/+server.ts
+++ b/src/routes/api/trending/+server.ts
@@ -1,0 +1,18 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { fetchTrending } from '$lib/server/trending';
+import { normalizeTrendingWindow, normalizeTrendingLanguage } from '$lib/types/trending';
+
+export const GET: RequestHandler = async ({ url, platform }) => {
+	const since = normalizeTrendingWindow(url.searchParams.get('since'));
+	const language = normalizeTrendingLanguage(url.searchParams.get('language'));
+
+	const result = await fetchTrending({
+		since,
+		language: language || undefined,
+		caches: platform?.caches,
+		waitUntil: platform?.context.waitUntil.bind(platform.context)
+	});
+
+	return json(result);
+};

--- a/src/routes/rankings/+page.svelte
+++ b/src/routes/rankings/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
+	import { goto, pushState } from '$app/navigation';
 	import { page } from '$app/stores';
 	import Header from '$lib/components/layout/Header.svelte';
 	import Footer from '$lib/components/layout/Footer.svelte';
@@ -12,13 +12,34 @@
 	import RepoTypeFilter from '$lib/components/ui/RepoTypeFilter.svelte';
 	import Card from '$lib/components/ui/Card.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
+	import SegmentedTabs from '$lib/components/ui/SegmentedTabs.svelte';
 	import type { RankedUser, RankedRepository } from '$lib/types/rankings';
+
+	type RankingsTab = 'repos' | 'users';
 
 	let { data } = $props();
 
-	// Derive active tab and repoType from URL for reactivity
-	let activeTab = $derived($page.url.searchParams.get('tab') || 'repos');
-	let repoType = $derived(($page.url.searchParams.get('repoType') as 'all' | 'original') || 'original');
+	// activeTab is local state (not derived from $page.url) because we use SvelteKit's
+	// shallow `pushState` for instant tab switching; pushState updates the browser URL
+	// without updating $page.url, so we can't rely on derivation for reactivity.
+	let activeTab = $state<RankingsTab>(
+		($page.url.searchParams.get('tab') as RankingsTab) || 'repos'
+	);
+
+	// Sync activeTab from URL on browser back/forward (popstate)
+	$effect(() => {
+		const handler = () => {
+			const next =
+				(new URL(window.location.href).searchParams.get('tab') as RankingsTab) || 'repos';
+			if (next !== activeTab) activeTab = next;
+		};
+		window.addEventListener('popstate', handler);
+		return () => window.removeEventListener('popstate', handler);
+	});
+
+	let repoType = $derived(
+		($page.url.searchParams.get('repoType') as 'all' | 'original') || 'original'
+	);
 
 	// Client-side user sort state
 	let userSortBy = $state<'followers' | 'stars'>('followers');
@@ -27,34 +48,35 @@
 	let resolvedUsers = $state<RankedUser[]>([]);
 	let resolvedRepos = $state<RankedRepository[]>([]);
 
+	type ReposResult = { success: boolean; data: RankedRepository[]; error?: string };
+	type UsersResult = { success: boolean; data: RankedUser[]; error?: string };
+
 	// Track loading states
-	let usersResult = $state<{ success: boolean; data: RankedUser[]; error?: string } | null>(null);
-	let reposResult = $state<{ success: boolean; data: RankedRepository[]; error?: string } | null>(null);
+	let usersResult = $state<UsersResult | null>(null);
+	let reposResult = $state<ReposResult | null>(null);
 
 	// Load More state
 	let loadingMore = $state(false);
 	let hasMoreRepos = $derived(resolvedRepos.length > 0 && resolvedRepos.length < 25);
 	let hasMoreUsers = $derived(resolvedUsers.length > 0 && resolvedUsers.length < 25);
 
-	// Load repos data via effect
+	// Streamed effects only run for the active tab; the inactive tab is server-stubbed
+	// to Promise.resolve({success:true, data:[]}) and tab-switch refetches via /api/rankings.
 	$effect(() => {
+		if (activeTab !== 'repos') return;
 		reposResult = null;
 		data.streamed.repos.then((result) => {
 			reposResult = result;
-			if (result.success) {
-				resolvedRepos = result.data;
-			}
+			if (result.success) resolvedRepos = result.data;
 		});
 	});
 
-	// Load users data via effect
 	$effect(() => {
+		if (activeTab !== 'users') return;
 		usersResult = null;
 		data.streamed.users.then((result) => {
 			usersResult = result;
-			if (result.success) {
-				resolvedUsers = result.data;
-			}
+			if (result.success) resolvedUsers = result.data;
 		});
 	});
 
@@ -73,16 +95,57 @@
 		}));
 	});
 
-	const tabs = [
-		{ id: 'repos', label: 'Top Repositories', icon: 'repo' },
-		{ id: 'users', label: 'Top Users', icon: 'user' }
+	const tabs: { value: RankingsTab; label: string }[] = [
+		{ value: 'repos', label: 'Top Repositories' },
+		{ value: 'users', label: 'Top Users' }
 	];
 
-	function switchTab(tabId: string) {
-		// Use goto to trigger server data reload for the new tab
+	function applyTabResult(tabId: RankingsTab, result: ReposResult | UsersResult | null) {
+		if (tabId === 'repos') {
+			reposResult = result as ReposResult | null;
+			if (result?.success) resolvedRepos = result.data as RankedRepository[];
+		} else {
+			usersResult = result as UsersResult | null;
+			if (result?.success) resolvedUsers = result.data as RankedUser[];
+		}
+	}
+
+	let inFlightFetch: AbortController | null = null;
+
+	async function switchTab(tabId: RankingsTab) {
+		if (tabId === activeTab) return;
+
+		// Optimistic UI: flip local state instantly so the active pill moves now
+		activeTab = tabId;
+
+		// Update browser URL (no server load round-trip)
 		const url = new URL($page.url);
 		url.searchParams.set('tab', tabId);
-		goto(url.toString(), { replaceState: true });
+		pushState(url, {});
+
+		// Cancel any in-flight tab fetch so a slow earlier response can't clobber newer state
+		inFlightFetch?.abort();
+		const controller = new AbortController();
+		inFlightFetch = controller;
+
+		applyTabResult(tabId, null);
+
+		const apiUrl = new URL('/api/rankings', window.location.origin);
+		apiUrl.searchParams.set('type', tabId);
+		apiUrl.searchParams.set('limit', '10');
+		apiUrl.searchParams.set('repoType', repoType);
+		if (tabId === 'repos' && data.language) {
+			apiUrl.searchParams.set('language', data.language);
+		}
+
+		try {
+			const res = await fetch(apiUrl.toString(), { signal: controller.signal });
+			const result = await res.json();
+			applyTabResult(tabId, result);
+		} catch (err) {
+			if (err instanceof DOMException && err.name === 'AbortError') return;
+			applyTabResult(tabId, { success: false, data: [], error: 'Failed to load' });
+		}
 	}
 
 	function changeRepoType(value: 'all' | 'original') {
@@ -140,9 +203,7 @@
 	<div class="relative z-10 mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
 		<!-- Header Section -->
 		<div class="mb-8 text-center">
-			<h1 class="mb-3 text-3xl font-bold text-text-primary sm:text-4xl">
-				GitHub Rankings
-			</h1>
+			<h1 class="mb-3 text-3xl font-bold text-text-primary sm:text-4xl">GitHub Rankings</h1>
 			<p class="text-lg text-text-secondary">
 				Discover the most starred repositories and influential developers
 			</p>
@@ -150,41 +211,29 @@
 
 		<!-- Tabs -->
 		<div class="mb-6 flex justify-center">
-			<div
-				class="inline-flex rounded-radius-md border border-border-default bg-bg-secondary p-1"
-			>
-				{#each tabs as tab (tab.id)}
-					<button
-						type="button"
-						onclick={() => switchTab(tab.id)}
-						class="flex cursor-pointer items-center gap-2 rounded-radius-sm px-4 py-2 text-sm font-medium transition-colors
-							{activeTab === tab.id
-							? 'bg-bg-tertiary text-text-primary'
-							: 'text-text-secondary hover:text-text-primary'}"
-					>
-						{#if tab.icon === 'repo'}
-							<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-									d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
-								/>
-							</svg>
-						{:else}
-							<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-									d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
-								/>
-							</svg>
-						{/if}
-						{tab.label}
-					</button>
-				{/each}
-			</div>
+			<SegmentedTabs items={tabs} value={activeTab} onchange={switchTab} ariaLabel="Rankings type">
+				{#snippet icon({ item })}
+					{#if item.value === 'repos'}
+						<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
+							/>
+						</svg>
+					{:else}
+						<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
+							/>
+						</svg>
+					{/if}
+				{/snippet}
+			</SegmentedTabs>
 		</div>
 
 		<!-- Filters -->
@@ -264,9 +313,7 @@
 		<!-- Load More Button -->
 		{#if (activeTab === 'repos' && hasMoreRepos) || (activeTab === 'users' && hasMoreUsers)}
 			<div class="mt-6 flex justify-center">
-				<Button variant="secondary" onclick={loadMore} loading={loadingMore}>
-					Load More
-				</Button>
+				<Button variant="secondary" onclick={loadMore} loading={loadingMore}>Load More</Button>
 			</div>
 		{/if}
 

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,22 +1,49 @@
 import type { RequestHandler } from './$types';
 import { SITE_URL } from '$lib/constants';
 import { fetchTopUsers } from '$lib/server/rankings';
+import { RANKING_LANGUAGES } from '$lib/types/rankings';
 
-const CACHE_KEY = `${SITE_URL}/__sitemap_cache_v1`;
+const CACHE_KEY = `${SITE_URL}/__sitemap_cache_v2`;
 const CACHE_TTL_SECONDS = 60 * 60 * 24;
+
+type Changefreq = 'daily' | 'weekly' | 'monthly';
 
 type StaticUrl = {
 	path: string;
-	changefreq: 'daily' | 'weekly' | 'monthly';
+	changefreq: Changefreq;
 	priority: string;
 };
 
 const STATIC_URLS: StaticUrl[] = [
 	{ path: '/', changefreq: 'weekly', priority: '1.0' },
 	{ path: '/rankings', changefreq: 'daily', priority: '0.9' },
+	{ path: '/trending', changefreq: 'daily', priority: '0.9' },
+	{ path: '/trending?since=weekly', changefreq: 'weekly', priority: '0.8' },
+	{ path: '/trending?since=monthly', changefreq: 'monthly', priority: '0.7' },
 	{ path: '/about', changefreq: 'monthly', priority: '0.5' },
 	{ path: '/privacy', changefreq: 'monthly', priority: '0.3' }
 ];
+
+const TRENDING_LANG_PRIORITIES: Record<Changefreq, string> = {
+	daily: '0.7',
+	weekly: '0.6',
+	monthly: '0.5'
+};
+
+function buildTrendingLanguageUrls(): StaticUrl[] {
+	const urls: StaticUrl[] = [];
+	for (const lang of RANKING_LANGUAGES) {
+		const langParam = encodeURIComponent(lang);
+		(['daily', 'weekly', 'monthly'] as const).forEach((since) => {
+			urls.push({
+				path: `/trending?language=${langParam}&since=${since}`,
+				changefreq: since,
+				priority: TRENDING_LANG_PRIORITIES[since]
+			});
+		});
+	}
+	return urls;
+}
 
 function escapeXml(value: string): string {
 	return value
@@ -30,10 +57,12 @@ function escapeXml(value: string): string {
 function buildSitemap(userLogins: string[]): string {
 	const lastmod = new Date().toISOString().split('T')[0];
 
-	const staticEntries = STATIC_URLS.map(
+	const allStatic = [...STATIC_URLS, ...buildTrendingLanguageUrls()];
+
+	const staticEntries = allStatic.map(
 		({ path, changefreq, priority }) =>
 			`  <url>\n` +
-			`    <loc>${SITE_URL}${path}</loc>\n` +
+			`    <loc>${SITE_URL}${escapeXml(path)}</loc>\n` +
 			`    <lastmod>${lastmod}</lastmod>\n` +
 			`    <changefreq>${changefreq}</changefreq>\n` +
 			`    <priority>${priority}</priority>\n` +

--- a/src/routes/trending/+page.server.ts
+++ b/src/routes/trending/+page.server.ts
@@ -1,0 +1,22 @@
+import type { PageServerLoad } from './$types';
+import { fetchTrending } from '$lib/server/trending';
+import { normalizeTrendingWindow, normalizeTrendingLanguage } from '$lib/types/trending';
+
+export const load: PageServerLoad = async ({ url, platform }) => {
+	const since = normalizeTrendingWindow(url.searchParams.get('since'));
+	const language = normalizeTrendingLanguage(url.searchParams.get('language'));
+
+	const repos = await fetchTrending({
+		since,
+		language: language || undefined,
+		caches: platform?.caches,
+		waitUntil: platform?.context.waitUntil.bind(platform.context)
+	});
+
+	return {
+		since,
+		language,
+		repos,
+		ownsCanonical: true
+	};
+};

--- a/src/routes/trending/+page.svelte
+++ b/src/routes/trending/+page.svelte
@@ -1,0 +1,250 @@
+<script lang="ts">
+	import { pushState } from '$app/navigation';
+	import Header from '$lib/components/layout/Header.svelte';
+	import Footer from '$lib/components/layout/Footer.svelte';
+	import Card from '$lib/components/ui/Card.svelte';
+	import FireIcon from '$lib/components/ui/FireIcon.svelte';
+	import SegmentedTabs from '$lib/components/ui/SegmentedTabs.svelte';
+	import TrendingTable from '$lib/components/rankings/TrendingTable.svelte';
+	import TrendingTableSkeleton from '$lib/components/rankings/TrendingTableSkeleton.svelte';
+	import TrendingFilters from '$lib/components/rankings/TrendingFilters.svelte';
+	import { SITE_URL } from '$lib/constants';
+	import {
+		TRENDING_WINDOWS,
+		WINDOW_LABEL,
+		WINDOW_PERIOD_TEXT,
+		DEFAULT_TRENDING_WINDOW,
+		type TrendingWindow,
+		type TrendingResult
+	} from '$lib/types/trending';
+
+	const windowItems = TRENDING_WINDOWS.map((w) => ({ value: w, label: WINDOW_LABEL[w] }));
+
+	let { data } = $props();
+
+	// Local state seeded from server load. Tab/filter changes use pushState (no full
+	// reload), so subsequent UI must drive off these refs rather than `data`. The $effect
+	// below re-syncs when the loader actually re-runs (e.g. external nav to /trending).
+	/* svelte-ignore state_referenced_locally */
+	let since = $state<TrendingWindow>(data.since);
+	/* svelte-ignore state_referenced_locally */
+	let language = $state<string>(data.language);
+	/* svelte-ignore state_referenced_locally */
+	let repos = $state<TrendingResult>(data.repos);
+	let loading = $state(false);
+
+	let inFlightFetch: AbortController | null = null;
+
+	// Re-sync when the load function actually re-runs (e.g. arriving via a header link
+	// to /trending with different params). pushState-driven changes don't fire this.
+	// Cancel any client fetch first so a stale response can't clobber fresh server data.
+	$effect(() => {
+		if (inFlightFetch) {
+			inFlightFetch.abort();
+			inFlightFetch = null;
+		}
+		since = data.since;
+		language = data.language;
+		repos = data.repos;
+		loading = false;
+	});
+
+	$effect(() => {
+		const handler = () => {
+			const u = new URL(window.location.href);
+			const nextSince = (u.searchParams.get('since') as TrendingWindow) || DEFAULT_TRENDING_WINDOW;
+			const nextLang = u.searchParams.get('language') || '';
+			if (nextSince === since && nextLang === language) return;
+			since = nextSince;
+			language = nextLang;
+			void fetchData();
+		};
+		window.addEventListener('popstate', handler);
+		return () => window.removeEventListener('popstate', handler);
+	});
+
+	async function fetchData() {
+		inFlightFetch?.abort();
+		const controller = new AbortController();
+		inFlightFetch = controller;
+		loading = true;
+
+		const apiUrl = new URL('/api/trending', window.location.origin);
+		apiUrl.searchParams.set('since', since);
+		if (language) apiUrl.searchParams.set('language', language);
+
+		try {
+			const res = await fetch(apiUrl.toString(), { signal: controller.signal });
+			const result = (await res.json()) as TrendingResult;
+			if (inFlightFetch === controller) repos = result;
+		} catch (err) {
+			if (err instanceof DOMException && err.name === 'AbortError') return;
+			if (inFlightFetch === controller) {
+				repos = { success: false, data: [], source: 'fallback', error: 'Failed to load' };
+			}
+		} finally {
+			if (inFlightFetch === controller) {
+				loading = false;
+				inFlightFetch = null;
+			}
+		}
+	}
+
+	function pushTrendingUrl() {
+		const url = new URL('/trending', window.location.origin);
+		if (since !== DEFAULT_TRENDING_WINDOW) url.searchParams.set('since', since);
+		if (language) url.searchParams.set('language', language);
+		pushState(url, {});
+	}
+
+	async function switchWindow(next: TrendingWindow) {
+		if (next === since) return;
+		since = next;
+		pushTrendingUrl();
+		await fetchData();
+	}
+
+	async function changeLanguage(next: string) {
+		if (next === language) return;
+		language = next;
+		pushTrendingUrl();
+		await fetchData();
+	}
+
+	const langPrefix = $derived(language ? `${language} ` : '');
+	const titleBase = $derived(`🔥 Trending ${langPrefix}Repos ${WINDOW_LABEL[since]} – CheckMyGit`);
+	const description = $derived(
+		`The 25 fastest-growing ${langPrefix}repositories on GitHub ${WINDOW_PERIOD_TEXT[since]}. Updated regularly.`
+	);
+	const h1Title = $derived(`Trending ${langPrefix}Repos ${WINDOW_LABEL[since]}`);
+
+	const canonicalUrl = $derived.by(() => {
+		const u = new URL(`${SITE_URL}/trending`);
+		if (since !== DEFAULT_TRENDING_WINDOW) u.searchParams.set('since', since);
+		if (language) u.searchParams.set('language', language);
+		return u.toString();
+	});
+
+	const jsonLdScript = $derived.by(() => {
+		if (!repos.success || repos.data.length === 0) return '';
+		const json = JSON.stringify({
+			'@context': 'https://schema.org',
+			'@type': 'ItemList',
+			name: h1Title,
+			description,
+			numberOfItems: repos.data.length,
+			itemListElement: repos.data.map((r) => ({
+				'@type': 'ListItem',
+				position: r.rank,
+				item: {
+					'@type': 'SoftwareSourceCode',
+					name: r.nameWithOwner,
+					url: r.url,
+					codeRepository: r.url,
+					programmingLanguage: r.language?.name,
+					description: r.description ?? undefined
+				}
+			}))
+		}).replace(/</g, '\\u003c');
+		return `<script type="application/ld+json">${json}</` + `script>`;
+	});
+</script>
+
+<svelte:head>
+	<title>{titleBase}</title>
+	<meta name="description" content={description} />
+	<link rel="canonical" href={canonicalUrl} />
+	<meta property="og:type" content="website" />
+	<meta property="og:title" content={titleBase} />
+	<meta property="og:description" content={description} />
+	<meta property="og:url" content={canonicalUrl} />
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content={titleBase} />
+	<meta name="twitter:description" content={description} />
+	{#if jsonLdScript}
+		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+		{@html jsonLdScript}
+	{/if}
+</svelte:head>
+
+<Header />
+
+<main class="relative min-h-screen w-full overflow-x-hidden">
+	<div class="saas-glow"></div>
+	<div class="grid-bg absolute inset-0 z-0"></div>
+
+	<div class="relative z-10 mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
+		<!-- Header section -->
+		<div class="mb-8 text-center">
+			<h1
+				class="mb-3 inline-flex items-center gap-2.5 text-3xl font-bold text-text-primary sm:text-4xl"
+			>
+				<FireIcon size={36} />
+				Trending
+				{#if language}
+					<span class="text-text-secondary">{language}</span>
+				{/if}
+			</h1>
+			<p class="text-lg text-text-secondary">
+				The hottest repositories on GitHub right now — updated regularly.
+			</p>
+		</div>
+
+		<!-- Window tabs -->
+		<div class="mb-6 flex justify-center">
+			<SegmentedTabs
+				items={windowItems}
+				value={since}
+				onchange={switchWindow}
+				ariaLabel="Time window"
+			>
+				{#snippet icon({ active })}
+					{#if active}<FireIcon size={14} />{/if}
+				{/snippet}
+			</SegmentedTabs>
+		</div>
+
+		<!-- Language filter -->
+		<div class="mb-6 flex flex-wrap items-center justify-center gap-4">
+			<TrendingFilters {language} onchange={changeLanguage} />
+		</div>
+
+		<!-- Content -->
+		<Card variant="default" padding="none">
+			{#if loading}
+				<TrendingTableSkeleton />
+			{:else if !repos.success}
+				<div class="p-8 text-center">
+					<svg
+						class="mx-auto mb-4 h-12 w-12 text-accent-red"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+						/>
+					</svg>
+					<p class="text-text-secondary">
+						{repos.error || 'Failed to load trending repositories'}
+					</p>
+				</div>
+			{:else if repos.data.length === 0}
+				<div class="p-8 text-center">
+					<p class="text-text-secondary">No trending repositories found.</p>
+				</div>
+			{:else}
+				<TrendingTable repos={repos.data} {since} />
+			{/if}
+		</Card>
+
+		<p class="mt-6 text-center text-sm text-text-tertiary">
+			Click any row to view the developer's CheckMyGit portfolio.
+		</p>
+	</div>
+</main>
+
+<Footer />


### PR DESCRIPTION
## Summary
- Adds `/trending` page covering **Today / This Week / This Month** windows with per-language filtering. Real GitHub trending data (scraped + edge-cached on Cloudflare) and a one-click jump from each row to the upstream repo.
- Extracts a reusable `SegmentedTabs` UI control and uses it on both `/trending` and `/rankings`. Replaces the broken `rounded-radius-*` Tailwind classes with proper styling (rounded outer, white active pill with shadow + ring).
- Fixes the **tab-switch latency** on `/rankings` (and now matches that fast-feeling UX on `/trending`) by switching from `goto()` (full server load round-trip) to `pushState` + a client fetch from a new `/api/rankings` // `/api/trending` endpoint, with a skeleton during the fetch and `AbortController` race protection.

## Why
- `/rankings` previously waited ~1s for a fresh GraphQL response before the active tab pill even moved. `/trending` first shipped using awaited SSR which felt fast on cache hits but blocked on cache miss. Both now flip instantly and show a skeleton — the perceived UX the user asked for.
- A real trending feed actually backs the `<changefreq>daily</changefreq>` we already advertise in `sitemap.xml`, and is a strong programmatic-SEO surface (per-combo unique title/description/canonical/JSON-LD ItemList).
- Each trending row links to the actual GitHub repo (new tab), while the avatar still links to the owner's CheckMyGit portfolio — preserving the cross-link moat for our profile pages.

## Architecture notes
- **Data source**: scrapes `github.com/trending?since=...&language=...` via Cloudflare's `caches.default` with per-window TTLs (daily 1h, weekly 6h, monthly 24h) + stale-while-revalidate. Falls back to `fetchTopRepositories` on scrape failure and caches the fallback briefly so GraphQL isn't hammered during outages.
- **Optimistic UI**: tabs/filters update local `$state` immediately, `pushState` updates the URL bar, then the new endpoint is fetched. Stale in-flight fetches are aborted on rapid switching. `popstate` listener syncs state on browser back/forward.
- **SEO**: full SSR for the initial paint (so JSON-LD + meta land in the initial HTML), and per-combo canonical via `data.ownsCanonical = true` so the layout doesn't emit a duplicate canonical for the page. Sitemap adds ~39 trending URLs.
- **Reuse**: `SegmentedTabs` (generic over `T extends string`, optional icon snippet), `FireIcon` (animated, respects `prefers-reduced-motion`), shared `normalizeTrendingWindow` / `normalizeTrendingLanguage` helpers used by both the page server load and the API endpoint.
