### PR TITLE
fix(header): hide trending/rankings on mobile profile page

### DIFF
--- a/src/lib/components/layout/header/HeaderActions.svelte
+++ b/src/lib/components/layout/header/HeaderActions.svelte
@@ -37,14 +37,13 @@
 </script>
 
 <div class="flex shrink-0 items-center gap-2">
-	<!-- Trending Link -->
-	<Button variant="ghost" size="sm" href="/trending">
+	<!-- Hidden in profile preview on mobile to avoid header overflow -->
+	<Button variant="ghost" size="sm" href="/trending" class={showControls ? 'hidden! sm:inline-flex!' : ''}>
 		<FireIcon size={16} />
 		<span class="hidden sm:inline">Trending</span>
 	</Button>
 
-	<!-- Rankings Link -->
-	<Button variant="ghost" size="sm" href="/rankings">
+	<Button variant="ghost" size="sm" href="/rankings" class={showControls ? 'hidden! sm:inline-flex!' : ''}>
 		<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 			<path
 				stroke-linecap="round"


### PR DESCRIPTION
## Summary
- Hide Trending and Rankings header buttons on mobile when on the profile preview page (`showControls={true}`)
- Prevents horizontal scroll on narrow viewports introduced by the new `/trending` button

## Test plan
- [x] Profile page at 375px: Trending/Rankings hidden, no horizontal overflow
- [x] Profile page at 320px: still no overflow
- [x] Profile page at ≥640px (sm breakpoint): both buttons visible with labels
- [x] Home page at 375px: both buttons still visible (non-profile pages unaffected)