### PR TITLE
fix(header): cache GitHub star count to prevent flicker on navigation

### DIFF
--- a/src/lib/components/layout/header/HeaderActions.svelte
+++ b/src/lib/components/layout/header/HeaderActions.svelte
@@ -2,7 +2,9 @@
 	import Button from '$lib/components/ui/Button.svelte';
 	import FireIcon from '$lib/components/ui/FireIcon.svelte';
 	import ThemeToggle from '$lib/components/ui/ThemeToggle.svelte';
-	import { REPO_URL, GITHUB_API_URL } from '$lib/constants';
+	import { REPO_URL } from '$lib/constants';
+	import { githubStarsState } from '$lib/stores/githubStars.svelte';
+	import { formatNumber } from '$lib/utils/github-transform';
 
 	interface Props {
 		showControls?: boolean;
@@ -13,27 +15,9 @@
 
 	let { showControls = false, onExport, onShare, onQRCode }: Props = $props();
 
-	let starCount = $state<number | null>(null);
-
 	$effect(() => {
-		fetch(GITHUB_API_URL)
-			.then((res) => res.json())
-			.then((data) => {
-				if (typeof data.stargazers_count === 'number') {
-					starCount = data.stargazers_count;
-				}
-			})
-			.catch(() => {
-				// Silently fail - button will still work without count
-			});
+		githubStarsState.init();
 	});
-
-	function formatStarCount(count: number): string {
-		if (count >= 1000) {
-			return (count / 1000).toFixed(1).replace(/\.0$/, '') + 'k';
-		}
-		return count.toString();
-	}
 </script>
 
 <div class="flex shrink-0 items-center gap-2">
@@ -99,10 +83,13 @@
 				d="M12 .587l3.668 7.568 8.332 1.151-6.064 5.828 1.48 8.279-7.416-3.967-7.417 3.967 1.481-8.279-6.064-5.828 8.332-1.151z"
 			/>
 		</svg>
-		{#if starCount !== null}
-			<span>{formatStarCount(starCount)} <span class="hidden sm:inline">Github</span></span>
-		{:else}
-			<span class="hidden sm:inline"> Github</span>
-		{/if}
+		<span class="inline-flex items-center gap-1">
+			{#if githubStarsState.count !== null}
+				<span class="tabular-nums">{formatNumber(githubStarsState.count)}</span>
+			{:else}
+				<span aria-hidden="true" class="inline-block h-3 w-7 animate-pulse rounded bg-text-tertiary/30"></span>
+			{/if}
+			<span class="hidden sm:inline">Github</span>
+		</span>
 	</Button>
 </div>

--- a/src/lib/stores/githubStars.svelte.ts
+++ b/src/lib/stores/githubStars.svelte.ts
@@ -1,0 +1,60 @@
+import { GITHUB_API_URL } from '$lib/constants';
+
+const CACHE_KEY = 'github-stars-v1';
+const TTL_MS = 60 * 60 * 1000;
+
+interface CacheEntry {
+	count: number;
+	expires: number;
+}
+
+class GithubStarsState {
+	count = $state<number | null>(null);
+	#initialized = false;
+
+	init() {
+		if (this.#initialized || typeof window === 'undefined') return;
+		this.#initialized = true;
+
+		let isFresh = false;
+		try {
+			const raw = localStorage.getItem(CACHE_KEY);
+			if (raw) {
+				const cached = JSON.parse(raw) as CacheEntry;
+				if (typeof cached.count === 'number' && typeof cached.expires === 'number') {
+					this.count = cached.count;
+					isFresh = cached.expires > Date.now();
+				}
+			}
+		} catch {
+			/* */
+		}
+
+		if (isFresh) return;
+
+		fetch(GITHUB_API_URL)
+			.then((res) => res.json())
+			.then((data) => {
+				if (typeof data.stargazers_count !== 'number') return;
+				if (this.count !== data.stargazers_count) {
+					this.count = data.stargazers_count;
+				}
+				try {
+					localStorage.setItem(
+						CACHE_KEY,
+						JSON.stringify({
+							count: data.stargazers_count,
+							expires: Date.now() + TTL_MS
+						} satisfies CacheEntry)
+					);
+				} catch {
+					/* */
+				}
+			})
+			.catch(() => {
+				/* */
+			});
+	}
+}
+
+export const githubStarsState = new GithubStarsState();


### PR DESCRIPTION
## Summary
- Header is rendered per-page (not in layout), so the star count was refetched on every navigation, briefly showing a null state and shifting the button width.
- Move state to a singleton store with localStorage TTL (1h, stale-while-revalidate). Singleton prevents per-mount refetch within session; localStorage covers reloads.
- Reserve button width via an inline pulse skeleton when count is null — eliminates layout shift on first load.

## Test plan
- [x] svelte-check: 0 errors
- [x] Playwright: skeleton width matches loaded width within ~0.78px on both desktop (124.28→123.5) and mobile (76→75.22)
- [x] Cache hit on reload renders count instantly with no skeleton flash
- [x] Navigation across `/`, `/trending`, `/rankings`, `/about`, `/privacy`, `/[username]` keeps count loaded with zero flicker
- [x] 0 console errors across all pages
- [ ] Cloudflare preview build succeeds