### PR TITLE
fix(header): expand mobile search on focus

### DIFF
--- a/src/lib/components/layout/Header.svelte
+++ b/src/lib/components/layout/Header.svelte
@@ -27,7 +27,7 @@
 </script>
 
 <header class="sticky top-0 z-50 w-full border-b border-border-default bg-bg-primary">
-	<div class="mx-auto flex h-16 w-full max-w-7xl items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
+	<div class="group mx-auto flex h-16 w-full max-w-7xl items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
 		<Logo />
 
 		<!-- Center section with search or controls -->
@@ -42,6 +42,10 @@
 			{/if}
 		</div>
 
-		<HeaderActions {showControls} {onExport} {onShare} {onQRCode} />
+		<div
+			class="flex items-center overflow-hidden transition-[max-width,opacity] duration-300 ease-out max-sm:max-w-[500px] max-sm:opacity-100 max-sm:group-has-[input:focus]:pointer-events-none max-sm:group-has-[input:focus]:max-w-0 max-sm:group-has-[input:focus]:opacity-0"
+		>
+			<HeaderActions {showControls} {onExport} {onShare} {onQRCode} />
+		</div>
 	</div>
 </header>

--- a/src/lib/components/layout/header/HeaderSearch.svelte
+++ b/src/lib/components/layout/header/HeaderSearch.svelte
@@ -8,7 +8,6 @@
 	let { username = '' }: Props = $props();
 
 	let searchValue = $state('');
-	let searchFocused = $state(false);
 
 	// Sync searchValue with the username prop whenever it changes
 	$effect(() => {
@@ -33,8 +32,6 @@
 		placeholder="Search users..."
 		bind:value={searchValue}
 		onkeydown={handleSearch}
-		onfocus={() => searchFocused = true}
-		onblur={() => searchFocused = false}
-		class="h-9 w-full rounded-lg border bg-bg-secondary pl-9 pr-3 text-sm text-text-primary placeholder-text-tertiary transition-all focus:border-saas-green focus:bg-bg-secondary focus:outline-none focus:ring-1 focus:ring-saas-green {searchFocused ? 'border-saas-green' : 'border-border-default'}"
+		class="h-9 w-full rounded-lg border border-border-default bg-bg-secondary pl-9 pr-3 text-sm text-text-primary placeholder-text-tertiary transition-all focus:border-saas-green focus:bg-bg-secondary focus:outline-none focus:ring-1 focus:ring-saas-green"
 	/>
 </div>


### PR DESCRIPTION
## Summary
- Mobile-only: when the search input gains focus, animate the right-side action buttons (trending / rankings / theme / GitHub stars) to collapse so the search has room to grow to its existing `max-w-80` (320px) ceiling.
- Implemented via Tailwind's `group-has-[input:focus]:` CSS-only modifier — no Svelte state or prop drilling. Desktop layout is unchanged.
- Removed the now-redundant `searchFocused` JS state in `HeaderSearch` and the dynamic border class binding (the `focus:border-saas-green` Tailwind variant already covers it).

## Test plan
- [x] Mobile (375×812): search ~64px collapsed, ~279px on focus, action buttons fade out / back in
- [x] Mobile blur: search collapses, actions reappear
- [x] Desktop (1280×900): all action buttons remain visible regardless of focus
- [x] Profile page (showControls=true): unchanged — search is not rendered there
- [x] `svelte-check` passes (no new warnings)