### PR TITLE
fix(trending): stream cold-cache fetch behind skeleton

### DIFF
--- a/src/lib/server/trending.ts
+++ b/src/lib/server/trending.ts
@@ -12,7 +12,11 @@ const TTL_BY_WINDOW: Record<TrendingWindow, { fresh: number; swr: number }> = {
 
 function buildCacheKey(since: TrendingWindow, language: string | undefined): string {
 	const lang = language ? language.toLowerCase() : 'all';
-	return `https://kv-cache/_/trending/${since}/${lang}`;
+	// Daily window keys include the UTC date so the 6h SWR window can't carry
+	// yesterday's "today" snapshot past midnight. Weekly/monthly rotate slowly
+	// enough that their TTLs alone are sufficient.
+	const dateSuffix = since === 'daily' ? `/${new Date().toISOString().slice(0, 10)}` : '';
+	return `https://kv-cache/_/trending/${since}/${lang}${dateSuffix}`;
 }
 
 function buildTrendingUrl(since: TrendingWindow, language: string | undefined): string {
@@ -117,7 +121,25 @@ interface FetchTrendingOptions {
 	waitUntil?: (p: Promise<unknown>) => void;
 }
 
-export async function fetchTrending({
+// Cache-only lookup. Returns null on miss so callers can decide whether to
+// block-and-fetch (api route) or stream a skeleton (page loader).
+export async function tryCachedTrending(options: {
+	since: TrendingWindow;
+	language?: string;
+	caches?: CacheStorage & { default: Cache };
+}): Promise<TrendingResult | null> {
+	if (!options.caches) return null;
+	const cacheKey = buildCacheKey(options.since, options.language);
+	const cached = await options.caches.default.match(new Request(cacheKey));
+	if (!cached) return null;
+	const data = (await cached.json()) as TrendingRepository[];
+	return { success: true, data, source: 'cache' };
+}
+
+// Slow path: scrape live, fall back to GraphQL on parse failure, write cache.
+// Always one upstream round-trip — callers should check the cache first if they
+// want to avoid it.
+export async function fetchTrendingLive({
 	since,
 	language,
 	caches,
@@ -125,14 +147,6 @@ export async function fetchTrending({
 }: FetchTrendingOptions): Promise<TrendingResult> {
 	const cacheKey = buildCacheKey(since, language);
 	const ttl = TTL_BY_WINDOW[since];
-
-	if (caches) {
-		const cached = await caches.default.match(new Request(cacheKey));
-		if (cached) {
-			const data = (await cached.json()) as TrendingRepository[];
-			return { success: true, data, source: 'cache' };
-		}
-	}
 
 	try {
 		const data = await fetchAndParse(since, language);
@@ -195,4 +209,12 @@ export async function fetchTrending({
 			error: error instanceof Error ? error.message : 'Unknown error'
 		};
 	}
+}
+
+// Convenience: cache-or-live in one call. Use this when the caller always
+// blocks on a result (e.g. the JSON API endpoint).
+export async function fetchTrending(options: FetchTrendingOptions): Promise<TrendingResult> {
+	const cached = await tryCachedTrending(options);
+	if (cached) return cached;
+	return fetchTrendingLive(options);
 }

--- a/src/routes/trending/+page.server.ts
+++ b/src/routes/trending/+page.server.ts
@@ -1,22 +1,33 @@
 import type { PageServerLoad } from './$types';
-import { fetchTrending } from '$lib/server/trending';
+import { tryCachedTrending, fetchTrendingLive } from '$lib/server/trending';
 import { normalizeTrendingWindow, normalizeTrendingLanguage } from '$lib/types/trending';
 
 export const load: PageServerLoad = async ({ url, platform }) => {
 	const since = normalizeTrendingWindow(url.searchParams.get('since'));
 	const language = normalizeTrendingLanguage(url.searchParams.get('language'));
 
-	const repos = await fetchTrending({
+	const cached = await tryCachedTrending({
 		since,
 		language: language || undefined,
-		caches: platform?.caches,
-		waitUntil: platform?.context.waitUntil.bind(platform.context)
+		caches: platform?.caches
 	});
 
+	if (cached) {
+		return { since, language, repos: cached, ownsCanonical: true };
+	}
+
+	// Cold cache: stream the live fetch (unawaited Promise) so SvelteKit ships
+	// the HTML shell + skeleton immediately and the data populates when it
+	// resolves. Cache hit above keeps full HTML + JSON-LD for warm traffic.
 	return {
 		since,
 		language,
-		repos,
-		ownsCanonical: true
+		ownsCanonical: true,
+		repos: fetchTrendingLive({
+			since,
+			language: language || undefined,
+			caches: platform?.caches,
+			waitUntil: platform?.context.waitUntil.bind(platform.context)
+		})
 	};
 };

--- a/src/routes/trending/+page.svelte
+++ b/src/routes/trending/+page.svelte
@@ -19,21 +19,37 @@
 	} from '$lib/types/trending';
 
 	const windowItems = TRENDING_WINDOWS.map((w) => ({ value: w, label: WINDOW_LABEL[w] }));
+	// Empty result used while a streamed SSR promise or a client filter-switch
+	// fetch is in flight. `loading` gates rendering, so callers never see this
+	// as a real result — `source` is just a stable placeholder.
+	const PENDING_REPOS: TrendingResult = { success: true, data: [], source: 'fallback' };
+	const FAILED_REPOS: TrendingResult = {
+		success: false,
+		data: [],
+		source: 'fallback',
+		error: 'Failed to load'
+	};
 
 	let { data } = $props();
 
-	// Local state seeded from server load. Tab/filter changes use pushState (no full
-	// reload), so subsequent UI must drive off these refs rather than `data`. The $effect
-	// below re-syncs when the loader actually re-runs (e.g. external nav to /trending).
+	// `data.repos` is `TrendingResult` on cache hit (full HTML in initial response)
+	// or `Promise<TrendingResult>` on cache miss (streamed). Initialize repos/loading
+	// to match so the SSR HTML reflects the cache state.
 	/* svelte-ignore state_referenced_locally */
 	let since = $state<TrendingWindow>(data.since);
 	/* svelte-ignore state_referenced_locally */
 	let language = $state<string>(data.language);
 	/* svelte-ignore state_referenced_locally */
-	let repos = $state<TrendingResult>(data.repos);
-	let loading = $state(false);
+	let repos = $state<TrendingResult>(
+		data.repos instanceof Promise ? PENDING_REPOS : data.repos
+	);
+	/* svelte-ignore state_referenced_locally */
+	let loading = $state<boolean>(data.repos instanceof Promise);
 
 	let inFlightFetch: AbortController | null = null;
+	// Token to ignore stale streamed-promise resolutions if the loader re-runs
+	// (or a client filter switch fires) before the original promise settles.
+	let streamToken = 0;
 
 	// Re-sync when the load function actually re-runs (e.g. arriving via a header link
 	// to /trending with different params). pushState-driven changes don't fire this.
@@ -45,8 +61,28 @@
 		}
 		since = data.since;
 		language = data.language;
-		repos = data.repos;
-		loading = false;
+
+		const incoming = data.repos;
+		if (incoming instanceof Promise) {
+			loading = true;
+			repos = PENDING_REPOS;
+			const token = ++streamToken;
+			incoming
+				.then((result) => {
+					if (token !== streamToken) return;
+					repos = result;
+					loading = false;
+				})
+				.catch(() => {
+					if (token !== streamToken) return;
+					repos = FAILED_REPOS;
+					loading = false;
+				});
+		} else {
+			streamToken++;
+			repos = incoming;
+			loading = false;
+		}
 	});
 
 	$effect(() => {
@@ -65,6 +101,9 @@
 
 	async function fetchData() {
 		inFlightFetch?.abort();
+		// Invalidate any pending streamed SSR promise so its late resolution
+		// can't clobber the response we're about to fetch here.
+		streamToken++;
 		const controller = new AbortController();
 		inFlightFetch = controller;
 		loading = true;
@@ -80,7 +119,7 @@
 		} catch (err) {
 			if (err instanceof DOMException && err.name === 'AbortError') return;
 			if (inFlightFetch === controller) {
-				repos = { success: false, data: [], source: 'fallback', error: 'Failed to load' };
+				repos = FAILED_REPOS;
 			}
 		} finally {
 			if (inFlightFetch === controller) {


### PR DESCRIPTION
## Summary

- Split `fetchTrending` into `tryCachedTrending` (cache-only) + `fetchTrendingLive` (scrape) so the page loader can decide between fast HTML or streamed skeleton per-request.
- Cache hit keeps the existing fast path: full HTML + JSON-LD shipped synchronously.
- Cache miss returns an unawaited `fetchTrendingLive` promise — SvelteKit streams the HTML shell + skeleton in ~100ms, data populates when GitHub responds.
- Daily cache keys now include the UTC date so the 6h stale-while-revalidate window can't serve yesterday's "Today" past midnight.

## Test plan

- [x] `npm run check` — 0 errors
- [x] Curl cold direct nav: TTFB 1453ms → ~99ms; HTML contains skeleton + streamed data.
- [x] Browser direct nav `/trending`: skeleton then table.
- [x] Header link click from homepage: page swaps and renders.
- [x] Tab switch daily ↔ weekly ↔ monthly: works, URL updates via pushState.
- [x] Language filter: works, URL updates.
- [x] Browser back-button (popstate): restores prior tab/lang.
- [ ] Verify Cloudflare preview build is green.