### PR TITLE
fix(theme): eliminate FOUC with pre-hydration script

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3,6 +3,25 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#030303" />
+		<script>
+			(function () {
+				try {
+					var stored = localStorage.getItem('theme');
+					var theme =
+						stored === 'dark' || stored === 'light'
+							? stored
+							: window.matchMedia('(prefers-color-scheme: dark)').matches
+								? 'dark'
+								: 'light';
+					if (theme === 'light') document.documentElement.classList.add('light');
+					document.documentElement.setAttribute('data-theme', theme);
+					var meta = document.querySelector('meta[name="theme-color"]');
+					if (meta) meta.setAttribute('content', theme === 'dark' ? '#030303' : '#FFFFFF');
+					window.__INITIAL_THEME__ = theme;
+				} catch (e) {}
+			})();
+		</script>
 		<link rel="preconnect" href="https://avatars.githubusercontent.com" crossorigin />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link rel="dns-prefetch" href="https://api.github.com" />

--- a/src/lib/stores/theme.svelte.ts
+++ b/src/lib/stores/theme.svelte.ts
@@ -1,41 +1,52 @@
 // Theme state management using Svelte 5 runes
-// Supports localStorage persistence and system preference detection
+// Initial theme is resolved by the inline pre-hydration script in app.html
+// (sets `.light` class on <html>, `data-theme` attr, and window.__INITIAL_THEME__).
+// This store reads that pre-resolved value to stay in sync, and handles
+// toggle/system-change updates after hydration.
 
 export type Theme = 'dark' | 'light';
 
 const STORAGE_KEY = 'theme';
+const META_DARK = '#030303';
+const META_LIGHT = '#FFFFFF';
+
+declare global {
+	interface Window {
+		__INITIAL_THEME__?: Theme;
+	}
+}
 
 class ThemeState {
 	current = $state<Theme>('dark');
 	#initialized = false;
 
-	constructor() {
-		// Initialization happens in init() to avoid SSR issues
-	}
-
 	init() {
 		if (this.#initialized || typeof window === 'undefined') return;
 		this.#initialized = true;
 
-		// Check localStorage first
-		const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
-		if (stored === 'dark' || stored === 'light') {
-			this.current = stored;
+		// Trust the pre-hydration script's resolved value if present
+		const preResolved = window.__INITIAL_THEME__;
+		if (preResolved === 'dark' || preResolved === 'light') {
+			this.current = preResolved;
 		} else {
-			// Fall back to system preference
-			const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-			this.current = prefersDark ? 'dark' : 'light';
+			const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+			if (stored === 'dark' || stored === 'light') {
+				this.current = stored;
+			} else {
+				this.current = window.matchMedia('(prefers-color-scheme: dark)').matches
+					? 'dark'
+					: 'light';
+			}
+			this.#applyTheme();
 		}
 
-		// Listen for system preference changes (only if no stored preference)
+		// Live-follow system pref only when user has not manually chosen
 		window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
 			if (!localStorage.getItem(STORAGE_KEY)) {
 				this.current = e.matches ? 'dark' : 'light';
 				this.#applyTheme();
 			}
 		});
-
-		this.#applyTheme();
 	}
 
 	toggle() {
@@ -59,6 +70,10 @@ class ThemeState {
 		} else {
 			root.classList.remove('light');
 		}
+		root.setAttribute('data-theme', this.current);
+
+		const meta = document.querySelector('meta[name="theme-color"]');
+		if (meta) meta.setAttribute('content', this.current === 'dark' ? META_DARK : META_LIGHT);
 	}
 
 	get isDark() {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -26,7 +26,6 @@
 </script>
 
 <svelte:head>
-	<meta name="theme-color" content={themeState.isDark ? '#030303' : '#FFFFFF'} />
 	<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 	{#if !pageOwnsCanonical}
 		<link rel="canonical" href="{SITE_URL}{$page.url.pathname}" />

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -118,10 +118,15 @@ html {
 	font-family: var(--font-sans);
 	background-color: var(--color-bg-primary);
 	color: var(--color-text-primary);
+	color-scheme: dark;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	scroll-behavior: smooth;
 	transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+:root.light {
+	color-scheme: light;
 }
 
 body {


### PR DESCRIPTION
## Summary
- Inline pre-hydration script in `app.html` resolves theme (localStorage > `prefers-color-scheme` > dark) and applies `.light` class + `data-theme` attr + meta `theme-color` **before first paint** — kills the black flash that light-mode users saw.
- Theme store reads `window.__INITIAL_THEME__` and keeps `<meta name="theme-color">` + `data-theme` in sync on toggle / system change.
- Added `color-scheme` CSS prop so native widgets (scrollbar, form controls) match the active theme.
- Removed duplicate reactive `<meta theme-color>` from `+layout.svelte` (now inline-managed).

## Issues fixed
1. Bg FOUC for light-mode users (default `current = 'dark'` + `init()` in `$effect`).
2. SSR `<meta theme-color>` always `#030303` → mobile address bar dark first.
3. Missing `color-scheme` declaration → native widgets mis-styled.
