### PR TITLE
fix(views): count via client beacon and debounce global counter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,3 @@
 # Create a token at: https://github.com/settings/tokens
 # Required scopes: read:user (public_repo optional for more data)
 GITHUB_TOKEN=ghp_your_token_here
-# Secret key for hashing IP addresses (Required for view counting)
-# Generate a random string (min 32 chars)
-IP_HASH_SECRET=replace_with_random_secure_string_at_least_32_chars_long

--- a/src/lib/server/kv/constants.ts
+++ b/src/lib/server/kv/constants.ts
@@ -11,6 +11,13 @@ export const STALE_CACHE_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour - max age for st
 // KV keys
 export const GLOBAL_VIEW_KEY = 'global:total_portfolios';
 
+// Global counter write-coalescing: the global key is touched by every counted
+// view, so we buffer increments in the edge cache and flush to KV at most once
+// per interval. This stops one hot key from draining the daily write quota; a
+// vanity total tolerates the resulting sub-minute lag.
+export const GLOBAL_FLUSH_INTERVAL_MS = 60 * 1000; // 1 minute
+export const GLOBAL_BUFFER_CACHE_KEY = 'https://kv-cache/_/global-view-buffer';
+
 // Retry configuration for KV operations (handles transient errors)
 export const DEFAULT_KV_RETRY_OPTIONS = {
 	maxRetries: 1,

--- a/src/lib/server/kv/deduplication.ts
+++ b/src/lib/server/kv/deduplication.ts
@@ -1,7 +1,5 @@
 import { DEDUP_COOKIE_NAME, DEDUP_WINDOW_MS, MAX_TRACKED_PROFILES } from './constants';
 import type { SeenProfile, CookieAccessor } from './types';
-import { createHmac } from 'crypto';
-import { env } from '$env/dynamic/private';
 
 export function parseSeenCookie(cookieValue: string | undefined): SeenProfile[] {
 	if (!cookieValue) return [];
@@ -103,19 +101,4 @@ export function handleDeduplication(
 		console.error('Deduplication error:', err);
 		return { shouldCount: true };
 	}
-}
-
-const SECRET_MIN_LENGTH = 32; // Enforce strong secrets
-// --- NEW ADDITION ---
-// Generate a secure hash of the IP address for privacy-preserving deduplication
-export function getIpHash(ip: string): string {
-	const IP_HASH_SECRET = env.IP_HASH_SECRET;
-	if (!IP_HASH_SECRET || IP_HASH_SECRET.length < SECRET_MIN_LENGTH) {
-		throw new Error(
-			`IP_HASH_SECRET is not configured or is too short (min ${SECRET_MIN_LENGTH} chars).`
-		);
-	}
-	// Handle empty IP (Upstream logic in view-counter.ts should prevent this, but good to be safe)
-	if (!ip) return '';
-	return createHmac('sha256', IP_HASH_SECRET).update(ip).digest('hex');
 }

--- a/src/lib/server/kv/global-counter.ts
+++ b/src/lib/server/kv/global-counter.ts
@@ -1,0 +1,114 @@
+import { GLOBAL_VIEW_KEY, GLOBAL_FLUSH_INTERVAL_MS, GLOBAL_BUFFER_CACHE_KEY } from './constants';
+import { buildGlobalCacheKey, setCachedCount } from './cache';
+import { kvReadWithRetry, type KV } from './retry';
+
+type Caches = CacheStorage & { default: Cache };
+
+// Pending global-view increments, held in the edge cache between flushes.
+interface GlobalBuffer {
+	delta: number;
+	lastFlushAt: number; // Unix ms
+}
+
+async function readBuffer(caches: Caches): Promise<GlobalBuffer> {
+	try {
+		const res = await caches.default.match(new Request(GLOBAL_BUFFER_CACHE_KEY));
+		if (res) {
+			const data = (await res.json()) as Partial<GlobalBuffer>;
+			if (typeof data.delta === 'number' && typeof data.lastFlushAt === 'number') {
+				return { delta: data.delta, lastFlushAt: data.lastFlushAt };
+			}
+		}
+	} catch {
+		// fall through to an empty buffer
+	}
+	return { delta: 0, lastFlushAt: 0 };
+}
+
+async function writeBuffer(caches: Caches, buffer: GlobalBuffer): Promise<void> {
+	try {
+		const res = new Response(JSON.stringify(buffer), {
+			headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }
+		});
+		await caches.default.put(new Request(GLOBAL_BUFFER_CACHE_KEY), res);
+	} catch {
+		// best-effort: losing the buffer only drops a few buffered increments
+	}
+}
+
+// Add `delta` to the durable global counter in KV and refresh its display cache.
+// Reads first and skips the write if the read fails, so a transient error never
+// clobbers the running total with a low value.
+async function flushToKV(kv: KV, caches: Caches | undefined, delta: number): Promise<boolean> {
+	let current: number | null = null;
+	try {
+		const value = await kvReadWithRetry(kv, GLOBAL_VIEW_KEY);
+		current = value ? parseInt(value, 10) : 0;
+	} catch (error) {
+		console.error('Global counter read failed, skipping flush:', error);
+	}
+	// Read failed: report that nothing was written so the caller keeps the
+	// buffered increments and retries, rather than dropping them.
+	if (current === null || Number.isNaN(current)) return false;
+
+	const next = current + delta;
+	await kv.put(GLOBAL_VIEW_KEY, next.toString());
+
+	if (caches) {
+		await setCachedCount(caches, buildGlobalCacheKey(), { count: next, cachedAt: Date.now() });
+	}
+	return true;
+}
+
+// Record one global view. Buffers increments in the edge cache and only writes
+// the single hot KV key at most once per GLOBAL_FLUSH_INTERVAL_MS, so it can't
+// absorb the whole daily write budget. Best-effort — never throws.
+//
+// Trade-offs (acceptable for a vanity total): the edge cache is per-colo and
+// evictable, so the buffer is approximate and the displayed total can lag by up
+// to the flush interval.
+export async function recordGlobalView(options: {
+	kv: KV;
+	caches?: Caches;
+	waitUntil?: (promise: Promise<unknown>) => void;
+}): Promise<void> {
+	const { kv, caches, waitUntil } = options;
+
+	// No edge cache available: fall back to a direct write so the counter still
+	// advances (this is the original, un-debounced behaviour).
+	if (!caches) {
+		try {
+			await flushToKV(kv, undefined, 1);
+		} catch (error) {
+			console.error('Global counter write failed:', error);
+		}
+		return;
+	}
+
+	try {
+		const buffer = await readBuffer(caches);
+		const delta = buffer.delta + 1;
+		const now = Date.now();
+
+		if (now - buffer.lastFlushAt >= GLOBAL_FLUSH_INTERVAL_MS) {
+			const flush = flushToKV(kv, caches, delta)
+				.then((written) =>
+					// Reset only once the write lands; otherwise keep the buffered
+					// increments and the old timestamp so the next view retries.
+					writeBuffer(
+						caches,
+						written ? { delta: 0, lastFlushAt: now } : { delta, lastFlushAt: buffer.lastFlushAt }
+					)
+				)
+				.catch((error) => console.error('Global counter flush failed:', error));
+
+			if (waitUntil) waitUntil(flush);
+			else await flush;
+		} else {
+			// Within the window: accumulate in the cache, no KV write.
+			await writeBuffer(caches, { delta, lastFlushAt: buffer.lastFlushAt });
+		}
+	} catch (error) {
+		console.error('recordGlobalView failed:', error);
+	}
+}

--- a/src/lib/server/kv/index.ts
+++ b/src/lib/server/kv/index.ts
@@ -1,5 +1,5 @@
 // KV optimization module for view counting
 // Provides caching, deduplication, and 429 error handling
 
-export { handleProfileView, getGlobalViewCount } from './view-counter';
-export type { ProfileViewResult, ViewCountResult, CookieAccessor } from './types';
+export { getProfileViews, recordProfileView, getGlobalViewCount } from './view-counter';
+export type { ViewCountResult, CookieAccessor } from './types';

--- a/src/lib/server/kv/retry.ts
+++ b/src/lib/server/kv/retry.ts
@@ -1,0 +1,44 @@
+import { DEFAULT_KV_RETRY_OPTIONS } from './constants';
+import type { KVRetryOptions } from './types';
+
+// KV namespace type, derived from the platform binding
+export type KV = App.Platform['env']['PROFILE_VIEWS'];
+
+// check if an error is a rate limit (429) error
+export function isRateLimitError(error: unknown): boolean {
+	if (error instanceof Error) {
+		const msg = error.message.toLowerCase();
+		return msg.includes('429') || msg.includes('rate limit') || msg.includes('too many');
+	}
+	return false;
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// read from KV with retry + exponential backoff on transient rate-limit errors
+export async function kvReadWithRetry(
+	kv: KV,
+	key: string,
+	options: KVRetryOptions = DEFAULT_KV_RETRY_OPTIONS
+): Promise<string | null> {
+	let lastError: Error | null = null;
+
+	for (let attempt = 0; attempt <= options.maxRetries; attempt++) {
+		try {
+			return await kv.get(key);
+		} catch (error) {
+			lastError = error as Error;
+
+			if (!isRateLimitError(error) || attempt === options.maxRetries) {
+				throw error;
+			}
+
+			const delay = options.retryDelayMs * Math.pow(options.backoffMultiplier, attempt);
+			await sleep(delay);
+		}
+	}
+
+	throw lastError;
+}

--- a/src/lib/server/kv/types.ts
+++ b/src/lib/server/kv/types.ts
@@ -17,14 +17,6 @@ export interface ViewCountResult {
 	source: 'cache' | 'kv' | 'fallback';
 }
 
-/** Result from handling a profile view */
-export interface ProfileViewResult {
-	views: number;
-	globalViews: number;
-	isStale: boolean;
-	source: 'cache' | 'kv' | 'fallback';
-}
-
 /** Options for KV read operations with retry */
 export interface KVRetryOptions {
 	maxRetries: number;

--- a/src/lib/server/kv/view-counter.ts
+++ b/src/lib/server/kv/view-counter.ts
@@ -1,12 +1,16 @@
 import {
-	DEFAULT_KV_RETRY_OPTIONS,
 	DEV_PROFILE_VIEWS,
 	DEV_GLOBAL_VIEWS,
 	GLOBAL_VIEW_KEY,
 	FALLBACK_VIEW_COUNT
 } from './constants';
-import type { ViewCountResult, ProfileViewResult, CookieAccessor, KVRetryOptions } from './types';
-import { handleDeduplication, getIpHash } from './deduplication';
+import type { ViewCountResult, CookieAccessor } from './types';
+import {
+	handleDeduplication,
+	getCookieName,
+	parseSeenCookie,
+	shouldCountView
+} from './deduplication';
 import {
 	getCachedCount,
 	setCachedCount,
@@ -15,55 +19,12 @@ import {
 	isCacheExpired,
 	isCacheTooStale
 } from './cache';
-
-const IP_DEDUP_TTL = 3600; // 1 hour in seconds
-
-// check if an error is a rate limit (429) error
-function isRateLimitError(error: unknown): boolean {
-	if (error instanceof Error) {
-		const msg = error.message.toLowerCase();
-		return msg.includes('429') || msg.includes('rate limit') || msg.includes('too many');
-	}
-	return false;
-}
-
-function sleep(ms: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, ms));
-}
+import { kvReadWithRetry } from './retry';
+import { recordGlobalView } from './global-counter';
 
 // check if platform has KV available (production vs local dev)
 function isKVAvailable(platform: App.Platform | undefined): boolean {
 	return !!platform?.env?.PROFILE_VIEWS;
-}
-
-// Extract KV type from App.Platform
-type KV = App.Platform['env']['PROFILE_VIEWS'];
-
-// read from KV with retry logic for rate limit errors
-async function kvReadWithRetry(
-	kv: KV,
-	key: string,
-	options: KVRetryOptions = DEFAULT_KV_RETRY_OPTIONS
-): Promise<string | null> {
-	let lastError: Error | null = null;
-
-	for (let attempt = 0; attempt <= options.maxRetries; attempt++) {
-		try {
-			return await kv.get(key);
-		} catch (error) {
-			lastError = error as Error;
-
-			if (!isRateLimitError(error) || attempt === options.maxRetries) {
-				throw error;
-			}
-
-			// Exponential backoff
-			const delay = options.retryDelayMs * Math.pow(options.backoffMultiplier, attempt);
-			await sleep(delay);
-		}
-	}
-
-	throw lastError;
 }
 
 // get view count with caching and fallback chain
@@ -126,148 +87,97 @@ async function getViewCount(
 	return { count: FALLBACK_VIEW_COUNT, isStale: false, source: 'fallback' };
 }
 
-// write view counts to KV and update cache
-async function writeViewCounts(
-	platform: App.Platform,
-	username: string,
-	profileCount: number,
-	globalCount: number
-): Promise<void> {
-	const kv = platform.env.PROFILE_VIEWS;
+// SSR display path: read-only profile view count. Never writes to KV and never
+// sets cookies. Adds an optimistic +1 when this visitor hasn't been counted yet
+// so the number reflects the current view immediately; the real increment is
+// persisted later by the /api/view beacon.
+// Designed to NEVER throw - always returns a number.
+export async function getProfileViews(options: {
+	platform: App.Platform | undefined;
+	username: string;
+	cookies: Pick<CookieAccessor, 'get'>;
+}): Promise<number> {
+	const { platform, username, cookies } = options;
 
+	// Local dev: return mock data
+	if (!isKVAvailable(platform)) return DEV_PROFILE_VIEWS;
+
+	const result = await getViewCount(platform, username.toLowerCase(), buildCacheKey(username));
+
+	// The fallback count already represents "1 for the current viewer" — don't
+	// stack another optimistic increment on top of it.
+	if (result.source === 'fallback') return result.count;
+
+	let optimistic = 0;
 	try {
-		// Write to KV
-		await Promise.all([
-			kv.put(username.toLowerCase(), profileCount.toString()),
-			kv.put(GLOBAL_VIEW_KEY, globalCount.toString())
-		]);
-
-		// Update cache with new values
-		if (platform.caches) {
-			await Promise.all([
-				setCachedCount(platform.caches, buildCacheKey(username), {
-					count: profileCount,
-					cachedAt: Date.now()
-				}),
-				setCachedCount(platform.caches, buildGlobalCacheKey(), {
-					count: globalCount,
-					cachedAt: Date.now()
-				})
-			]);
-		}
-	} catch (error) {
-		console.error('Failed to write view counts:', error);
-		// Writes failed, but page already loaded - log and move on
+		const seen = parseSeenCookie(cookies.get(getCookieName()));
+		if (shouldCountView(seen, username)) optimistic = 1;
+	} catch {
+		// Cookie parse failure: just show the persisted count
 	}
+
+	return result.count + optimistic;
 }
 
-// handle a profile view with deduplication, caching, and 429 fallback
-// This function is designed to NEVER throw - always returns a valid result
-export async function handleProfileView(options: {
+// Write path: dedupe by cookie, increment the per-profile counter, and record a
+// (debounced) global view. Invoked by the /api/view beacon, which only fires in
+// real browsers — so crawlers (which don't run JS) never reach the write path.
+// Designed to NEVER throw.
+export async function recordProfileView(options: {
 	platform: App.Platform | undefined;
 	username: string;
 	cookies: CookieAccessor;
-	ip: string;
-}): Promise<ProfileViewResult> {
-	const { platform, username, cookies, ip } = options;
+}): Promise<void> {
+	const { platform, username, cookies } = options;
 
-	// Local dev: return mock data
-	if (!isKVAvailable(platform)) {
-		return {
-			views: DEV_PROFILE_VIEWS,
-			globalViews: DEV_GLOBAL_VIEWS,
-			isStale: false,
-			source: 'fallback'
-		};
-	}
+	// Local dev or missing binding: nothing to persist.
+	if (!platform || !isKVAvailable(platform)) return;
 
 	try {
-		// 1. Check deduplication (Cookie + IP Check, wrapped in try-catch for safety)
-		let shouldCount = true;
+		// Now that only real browsers reach this path, the cookie window is enough
+		// on its own: it both decides whether to count and records the visit (24h).
+		const { shouldCount } = handleDeduplication(cookies, username);
+		if (!shouldCount) return;
 
+		const kv = platform.env.PROFILE_VIEWS;
+		const caches = platform.caches;
+		const waitUntil = platform.context?.waitUntil
+			? platform.context.waitUntil.bind(platform.context)
+			: undefined;
+
+		const key = username.toLowerCase();
+
+		// Read-then-increment. If the read fails, skip the write so a transient
+		// error can never reset the counter to a low value.
+		let current: number | null = null;
 		try {
-			// A. Check Cookie (Fastest check first)
-			const result = handleDeduplication(cookies, username);
-			shouldCount = result.shouldCount;
+			const value = await kvReadWithRetry(kv, key);
+			current = value ? parseInt(value, 10) : 0;
+		} catch (error) {
+			console.error('Profile count read failed, skipping increment:', error);
+		}
+		if (current === null || Number.isNaN(current)) return;
 
-			// B. Check IP Hash in KV (Secure check for Incognito/Scripts)
-			// Only check if cookie said "yes" and we have access to the DB
-			if (shouldCount && isKVAvailable(platform) && ip) {
-				const kv = platform!.env.PROFILE_VIEWS;
-				const ipHash = getIpHash(ip);
-				const dedupKey = `dedup:${ipHash}:${username.toLowerCase()}`;
+		const next = current + 1;
+		await kv.put(key, next.toString());
 
-				// Check if this IP has viewed this profile recently
-				const hasViewedByIp = await kv.get(dedupKey);
-
-				if (hasViewedByIp) {
-					shouldCount = false;
-				} else {
-					// Mark this IP as "seen" for the next hour
-					// Use waitUntil so we don't slow down the page load
-					const writePromise = kv.put(dedupKey, '1', { expirationTtl: IP_DEDUP_TTL });
-
-					if (platform!.context) {
-						platform!.context.waitUntil(writePromise);
-					} else {
-						writePromise.catch((e: unknown) => console.error('Failed to log IP:', e));
-					}
-				}
-			}
-		} catch (err) {
-			console.error('Deduplication check failed:', err);
-			// Fail open: If DB errors, we count the view rather than breaking the page
+		// Refresh the display cache so the next SSR read reflects the new value.
+		if (caches) {
+			await setCachedCount(caches, buildCacheKey(username), {
+				count: next,
+				cachedAt: Date.now()
+			});
 		}
 
-		// 2. Get current view counts (with caching/fallback)
-		const [profileViews, globalViews] = await Promise.all([
-			getViewCount(platform, username.toLowerCase(), buildCacheKey(username)),
-			getViewCount(platform, GLOBAL_VIEW_KEY, buildGlobalCacheKey())
-		]);
-
-		// 3. Calculate display values
-		let displayViews = profileViews.count;
-		let displayGlobal = globalViews.count;
-
-		if (shouldCount) {
-			// Show incremented value to user immediately
-			displayViews += 1;
-			displayGlobal += 1;
-
-			// 4. Perform writes in background (never block response)
-			if (platform?.env?.PROFILE_VIEWS && platform.context?.waitUntil) {
-				platform.context.waitUntil(
-					writeViewCounts(platform, username, displayViews, displayGlobal)
-				);
-			} else if (platform?.env?.PROFILE_VIEWS) {
-				// Fallback without waitUntil - fire and forget
-				writeViewCounts(platform, username, displayViews, displayGlobal).catch((err) =>
-					console.error('Background write failed:', err)
-				);
-			}
-		}
-
-		return {
-			views: displayViews,
-			globalViews: displayGlobal,
-			isStale: profileViews.isStale || globalViews.isStale,
-			source: profileViews.source
-		};
+		// Global total: buffered and flushed at most once per minute.
+		await recordGlobalView({ kv, caches, waitUntil });
 	} catch (error) {
-		// Ultimate safety net - if anything unexpected fails, return fallback
-		// Show 1 because current user IS viewing the page
-		console.error('handleProfileView failed:', error);
-		return {
-			views: FALLBACK_VIEW_COUNT,
-			globalViews: FALLBACK_VIEW_COUNT,
-			isStale: false,
-			source: 'fallback'
-		};
+		console.error('recordProfileView failed:', error);
 	}
 }
 
-// get global view count (for homepage)
-// Uses caching to minimize KV reads
+// get global view count (for homepage) - read-only, cache-first.
+// Uses caching to minimize KV reads.
 export async function getGlobalViewCount(
 	platform: App.Platform | undefined
 ): Promise<ViewCountResult> {

--- a/src/routes/[username]/+page.server.ts
+++ b/src/routes/[username]/+page.server.ts
@@ -1,8 +1,8 @@
 import type { PageServerLoad } from './$types';
 import { fetchGitHubProfile } from '$lib/server/github';
-import { handleProfileView } from '$lib/server/kv';
+import { getProfileViews } from '$lib/server/kv';
 
-export const load: PageServerLoad = async ({ params, platform, cookies, getClientAddress }) => {
+export const load: PageServerLoad = async ({ params, platform, cookies }) => {
 	const { username } = params;
 
 	// Return username immediately for optimistic UI
@@ -21,18 +21,14 @@ export const load: PageServerLoad = async ({ params, platform, cookies, getClien
 		return result.data;
 	});
 
-	// Stream view count as well (with fallback to 0 on error)
-	const viewsPromise = handleProfileView({
+	// Read-only: render the current count (with an optimistic +1 for new
+	// visitors). The actual increment is persisted by the /api/view beacon, which
+	// only fires in real browsers — keeping crawlers off the KV write path.
+	const viewsPromise = getProfileViews({
 		platform,
 		username,
-		cookies: {
-			get: (name) => cookies.get(name),
-			set: (name, value, opts) => cookies.set(name, value, opts)
-		},
-		ip: getClientAddress()
-	})
-		.then((result) => result.views)
-		.catch(() => 0);
+		cookies: { get: (name) => cookies.get(name) }
+	}).catch(() => 0);
 
 	return {
 		username,

--- a/src/routes/[username]/+page.svelte
+++ b/src/routes/[username]/+page.svelte
@@ -29,16 +29,44 @@
 	let profile = $state<GitHubProfile | null>(null);
 	let views = $state<number>(0);
 
+	// Which username we've already sent a view beacon for. Plain (non-reactive)
+	// variable so client-side navigation between profiles counts each one once.
+	let countedUser = '';
+
+	// Fire-and-forget view beacon. Running this client-side means crawlers (which
+	// don't execute JS) never hit the KV write path. Best-effort: must never throw
+	// or affect the UI.
+	function sendViewBeacon(username: string) {
+		try {
+			void fetch('/api/view', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ username }),
+				keepalive: true
+			}).catch(() => {});
+		} catch {
+			// ignore
+		}
+	}
+
 	// Resolve the streamed promises
 	$effect(() => {
 		isLoading = true;
 		loadError = null;
+		const requestedUser = data.username;
 
 		Promise.all([data.profile, data.views])
 			.then(([resolvedProfile, resolvedViews]) => {
 				profile = resolvedProfile;
 				views = resolvedViews;
 				isLoading = false;
+
+				// Count the view only after the profile actually resolves (so 404s
+				// aren't counted) and only once per profile.
+				if (countedUser !== requestedUser) {
+					countedUser = requestedUser;
+					sendViewBeacon(requestedUser);
+				}
 			})
 			.catch((err) => {
 				loadError = err;

--- a/src/routes/api/view/+server.ts
+++ b/src/routes/api/view/+server.ts
@@ -1,0 +1,35 @@
+import type { RequestHandler } from './$types';
+import { recordProfileView } from '$lib/server/kv';
+
+// GitHub usernames: 1–39 chars, alphanumeric with single internal hyphens, no
+// leading/trailing hyphen. Validating here stops the public beacon from being
+// used to create arbitrary KV keys.
+const USERNAME_RE = /^[a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d])){0,38}$/;
+
+// Records a single profile view. Fired as a fire-and-forget beacon from the
+// profile page after it loads in a real browser, which keeps crawlers (no JS)
+// off the KV write path.
+export const POST: RequestHandler = async ({ request, platform, cookies }) => {
+	let username: unknown;
+	try {
+		const body = (await request.json()) as { username?: unknown };
+		username = body?.username;
+	} catch {
+		return new Response(null, { status: 400 });
+	}
+
+	if (typeof username !== 'string' || !USERNAME_RE.test(username)) {
+		return new Response(null, { status: 400 });
+	}
+
+	await recordProfileView({
+		platform,
+		username,
+		cookies: {
+			get: (name) => cookies.get(name),
+			set: (name, value, opts) => cookies.set(name, value, opts)
+		}
+	});
+
+	return new Response(null, { status: 204 });
+};


### PR DESCRIPTION
## Problem
Profile view counting ran in the SSR `load` of `/[username]`, so every request — including cookieless crawlers — issued KV writes. Each counted view cost 3 writes (IP-dedup key + per-profile counter + the shared global counter), and `global:total_portfolios` is a single hot key written on every view. The free-tier 1,000 writes/day limit was being exhausted within minutes of the daily reset, mostly from crawler traffic rather than real visitors.

## Changes
- **Count via a client beacon.** The increment moves to `POST /api/view`, fired from the browser after the profile loads. Crawlers don't execute JS, so they no longer touch the write path. SSR now only *reads* the count (with an optimistic +1 for new visitors), so the displayed number is unchanged.
- **Drop the per-IP KV dedup write.** With only real browsers reaching the write path, the existing 24h cookie window is enough. Removes the now-unused IP-hashing helper and `IP_HASH_SECRET`.
- **Debounce the global counter.** Increments are buffered in the edge cache and flushed to KV at most once per minute instead of on every view. The buffer only resets on a successful flush, so a transient KV error retries rather than dropping counts.
- **Validate the username** in the beacon endpoint so it can't be used to create arbitrary KV keys.

## Behaviour / trade-offs
- No UX change: the count still renders on load; the beacon is fire-and-forget.
- Views are counted only for real browsers and only after the profile resolves (404s no longer count).
- The global total can lag by up to the flush interval (~1 min); the edge-cache buffer is per-colo and best-effort. Acceptable for a vanity counter.

## Testing
- `npm run check` and `npm run build` pass.
- Lint/format clean on the changed files (pre-existing repo lint backlog untouched).
