### PR TITLE
fix: trim username before validation in Hero search bar

### DIFF
--- a/src/lib/components/landing/Hero.svelte
+++ b/src/lib/components/landing/Hero.svelte
@@ -17,13 +17,14 @@
 	let isLoading = $derived(navigationState.isLoading);
 
 	async function handleSubmit() {
-		const validation = validateGitHubUsername(username);
+		const trimmed = username.trim();
+		const validation = validateGitHubUsername(trimmed);
 		if (!validation.valid) {
 			error = validation.errors[0];
 			return;
 		}
 		error = '';
-		await navigationState.navigateToProfile(username.trim());
+		await navigationState.navigateToProfile(trimmed);
 	}
 
 	function handleKeydown(e: KeyboardEvent) {


### PR DESCRIPTION

This PR fixes an issue where searching for a GitHub username with leading or trailing whitespace (e.g. `torvalds  ` or `  torvalds`) fails with a validation error instead of resolving the profile.

## Root Cause

In `Hero.svelte`, `handleSubmit` validated the username before trimming it. Although `.trim()` was already being applied, it was only used when calling `navigateToProfile`, so the validation step never received the trimmed value.

## Fix

- Trim the username at the beginning of `handleSubmit`.
- Reuse the trimmed value for both validation and navigation.
- No changes were required in `HeaderSearch.svelte`, as its search handler already trims the input correctly.

## Testing

Verified the following cases:

- ✅ `torvalds`
- ✅ `torvalds `
- ✅ ` torvalds`
- ✅ Input containing only whitespace (`"   "`) is treated as empty.